### PR TITLE
Add CI/CD workflows with NPM trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: pnpm/action-setup@v4
+        with:
+          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: '22'  # Includes npm 11+ for OIDC support


### PR DESCRIPTION
## Summary
- **ci.yml**: Runs lint, typecheck, test, build on PRs and pushes to main
- **publish.yml**: Publishes to NPM via OIDC trusted publishers on merge
  - Auto-bumps patch version based on NPM registry
  - Only triggers when package files change (src, bin, package.json, etc.)
  - Manual dispatch available for force publish

## Test plan
- [ ] CI workflow runs and passes on this PR
- [ ] Merge to main does NOT trigger publish (only workflow files changed)
- [ ] After merge, add `check` as required status check in branch protection

🤖 Generated with [Claude Code](https://claude.com/claude-code)