### PR TITLE
Fix trusted publishing: use Node 24 for OIDC support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
       - 'bin/**'
       - 'package.json'
       - 'tsconfig*.json'
-      - 'build.ts'
+      - 'tsup.config.ts'
   workflow_dispatch:  # Manual trigger (bypasses path filter)
 
 jobs:
@@ -23,7 +23,7 @@ jobs:
           bun-version: latest
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'  # Includes npm 11+ for OIDC support
+          node-version: '24'  # Ships with npm 11+ for OIDC trusted publishing
           registry-url: 'https://registry.npmjs.org'
 
       - run: bun install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Use Node 24 which ships with cli v11+ (required for OIDC trusted publishing)
- Node 22 ships with cli v10.9.x which causes 404 errors
- Also updates paths trigger for tsup.config.ts

## References

- https://github.com/npm/cli/issues/8678