### PR TITLE
Remove Windows-incompatible filename (*.ts.md)

### DIFF
--- a/.claude/rules/*.ts.md
+++ b/.claude/rules/*.ts.md
@@ -1,8 +1,0 @@
----
-# Empty frontmatter - this rule has no validation
-# Linting and type checking should be done via dedicated hooks instead
----
-
-# TypeScript Files Rule
-
-This rule applies to all TypeScript files. Linting and type checking is handled by dedicated PostToolUse hooks in the nextjs-supabase-ai-sdk-dev plugin.


### PR DESCRIPTION
## Summary
- Removes `.claude/rules/*.ts.md` which contains an asterisk character
- Asterisks are not valid filename characters on Windows
- This prevents the repo from being cloned/checked out on Windows systems

## Test plan
- [x] Verified repo can be cloned on Windows after this change
- [x] All other plugin files are intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)