### PR TITLE
Add cloudflare-workers-mcp-dev plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,6 +49,16 @@
       },
       "source": "./plugins/nodes-md-integration",
       "strict": false
+    },
+    {
+      "name": "cloudflare-workers-mcp-dev",
+      "description": "Cloudflare Workers development with MCP servers for bindings, builds, observability, containers, and browser rendering",
+      "version": "0.1.0",
+      "author": {
+        "name": "constellos"
+      },
+      "source": "./plugins/cloudflare-workers-mcp-dev",
+      "strict": false
     }
   ]
 }

--- a/plugins/cloudflare-workers-mcp-dev/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-workers-mcp-dev/.claude-plugin/plugin.json
@@ -1,0 +1,44 @@
+{
+  "name": "cloudflare-workers-mcp-dev",
+  "version": "0.1.0",
+  "description": "Cloudflare Workers development with MCP servers for bindings, builds, observability, containers, and browser rendering",
+  "author": {
+    "name": "constellos"
+  },
+  "repository": "https://github.com/constellos/claude-code-plugins",
+  "license": "MIT",
+  "keywords": [
+    "cloudflare",
+    "workers",
+    "mcp",
+    "serverless",
+    "wrangler",
+    "durable-objects"
+  ],
+  "mcpServers": {
+    "cloudflare-bindings": {
+      "command": "npx",
+      "args": ["mcp-remote@latest", "https://bindings.mcp.cloudflare.com/mcp"]
+    },
+    "cloudflare-docs": {
+      "command": "npx",
+      "args": ["mcp-remote@latest", "https://docs.mcp.cloudflare.com/mcp"]
+    },
+    "cloudflare-builds": {
+      "command": "npx",
+      "args": ["mcp-remote@latest", "https://builds.mcp.cloudflare.com/mcp"]
+    },
+    "cloudflare-observability": {
+      "command": "npx",
+      "args": ["mcp-remote@latest", "https://observability.mcp.cloudflare.com/mcp"]
+    },
+    "cloudflare-containers": {
+      "command": "npx",
+      "args": ["mcp-remote@latest", "https://containers.mcp.cloudflare.com/mcp"]
+    },
+    "cloudflare-browser": {
+      "command": "npx",
+      "args": ["mcp-remote@latest", "https://browser.mcp.cloudflare.com/mcp"]
+    }
+  }
+}

--- a/plugins/cloudflare-workers-mcp-dev/CLAUDE.md
+++ b/plugins/cloudflare-workers-mcp-dev/CLAUDE.md
@@ -1,0 +1,44 @@
+---
+title: Cloudflare Workers MCP Dev
+description: MCP servers for Cloudflare Workers development
+version: 0.1.0
+folder:
+  subfolders:
+    allowed: [.claude-plugin]
+    required: [.claude-plugin]
+  files:
+    allowed: [CLAUDE.md, README.md]
+    required: [README.md]
+---
+
+# Cloudflare Workers MCP Dev
+
+## Quick Reference
+
+Provides 6 Cloudflare MCP servers for Workers development:
+
+| Server | Use For |
+|--------|---------|
+| `cloudflare-bindings` | KV, R2, D1, Durable Objects, AI primitives |
+| `cloudflare-docs` | Cloudflare documentation lookup |
+| `cloudflare-builds` | Workers Builds management |
+| `cloudflare-observability` | Logs, analytics, error debugging |
+| `cloudflare-containers` | Sandbox dev environments |
+| `cloudflare-browser` | Screenshots, markdown conversion |
+
+## When to Use
+
+- Building Cloudflare Workers applications
+- Debugging Workers in production
+- Looking up Cloudflare documentation
+- Testing code in isolated containers
+- Scraping or capturing web content
+
+## Authentication
+
+OAuth via Cloudflare account. Prompted on first use.
+
+## See Also
+
+- [Cloudflare Agents Docs](https://developers.cloudflare.com/agents/)
+- [MCP Servers for Cloudflare](https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/)

--- a/plugins/cloudflare-workers-mcp-dev/README.md
+++ b/plugins/cloudflare-workers-mcp-dev/README.md
@@ -1,0 +1,60 @@
+# Cloudflare Workers MCP Dev
+
+> Cloudflare Workers development with MCP servers for bindings, builds, observability, containers, and browser rendering.
+
+## Overview
+
+This plugin provides access to Cloudflare's managed MCP servers for developing and debugging Cloudflare Workers applications. Each MCP server connects via OAuth and provides specialized tools for different aspects of Workers development.
+
+## MCP Servers Included
+
+| Server | Purpose |
+|--------|---------|
+| **cloudflare-bindings** | Build Workers with storage (KV, R2, D1, Durable Objects), AI, and compute primitives |
+| **cloudflare-docs** | Access up-to-date Cloudflare Developer Documentation |
+| **cloudflare-builds** | Manage and monitor Workers Builds deployments |
+| **cloudflare-observability** | Debug logs, analytics, and error traces for Workers |
+| **cloudflare-containers** | Spin up sandbox development environments on demand |
+| **cloudflare-browser** | Fetch web pages, convert to markdown, and take screenshots |
+
+## Installation
+
+```bash
+# Add the constellos marketplace
+claude plugin marketplace add https://github.com/constellos/claude-code-plugins
+
+# Install this plugin
+claude plugin install cloudflare-workers-mcp-dev@constellos
+```
+
+Or add to your project's `.claude/settings.json`:
+
+```json
+{
+  "enabledPlugins": {
+    "cloudflare-workers-mcp-dev@constellos": true
+  }
+}
+```
+
+## Authentication
+
+Each MCP server requires OAuth authentication with your Cloudflare account. On first use, you'll be prompted to authorize access through Cloudflare's OAuth flow.
+
+## Use Cases
+
+- **Building Workers**: Use bindings server to interact with KV, R2, D1, and Durable Objects
+- **Debugging**: Use observability server to browse invocation logs and isolate errors
+- **Documentation**: Use docs server to get current Cloudflare documentation
+- **Testing**: Use containers server for isolated sandbox environments
+- **Web Scraping**: Use browser server for screenshots and page content extraction
+
+## References
+
+- [Cloudflare MCP Servers Documentation](https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/)
+- [mcp-remote package](https://www.npmjs.com/package/mcp-remote)
+- [cloudflare/mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare)
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

New plugin providing 6 Cloudflare MCP servers for Workers development:

| Server | Purpose |
|--------|---------|
| cloudflare-bindings | KV, R2, D1, Durable Objects, AI primitives |
| cloudflare-docs | Cloudflare documentation lookup |
| cloudflare-builds | Workers Builds management |
| cloudflare-observability | Logs, analytics, error debugging |
| cloudflare-containers | Sandbox dev environments |
| cloudflare-browser | Screenshots, markdown conversion |

Uses `mcp-remote` to connect to Cloudflare's managed MCP servers via OAuth.

## Test plan

- [ ] Install plugin and verify MCP servers connect
- [ ] Test OAuth flow with Cloudflare account
- [ ] Verify tools are available in Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)