### PR TITLE
Fix merge conflict in settings.json and worktree plugin cleanup bug

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -88,14 +88,9 @@
       }
     ]
   },
-<<<<<<< HEAD
-=======
   "enabledPlugins": {
-    "project-context@constellos": true,
-    "nextjs-supabase-ai-sdk-dev@constellos": true,
-    "github-context@constellos": true
+    "plugin-dev@claude-code-plugins": true
   },
->>>>>>> origin/main
   "extraKnownMarketplaces": {
     "constellos": {
       "source": {


### PR DESCRIPTION
## Summary

- **settings.json**: Remove merge conflict markers that were accidentally committed in PR #78
  - Keep only `plugin-dev@claude-code-plugins` as project-scoped plugin
  - User-scoped plugins (github-context, project-context, etc.) are managed globally

- **claude-worktree.sh**: Remove buggy `_cleanup_invalid_plugins` function
  - Was checking `${repo_root}/plugins/` which only exists in this repo
  - Was incorrectly deleting user-scoped plugin caches when run from other projects
  - Now only refreshes project-scoped plugins from `.claude/settings.json`

## Test plan

- [ ] Run `claude-worktree` from lazyjobs - should NOT delete user-scoped plugin caches
- [ ] Run `claude-worktree` from claude-code-plugins - should work normally
- [ ] Verify `.claude/settings.json` has valid JSON (no conflict markers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)