### PR TITLE
fix: remove missing enforce-plan-scoping hook, update MCP servers, fix cache clearing

### DIFF
--- a/claude-worktree.sh
+++ b/claude-worktree.sh
@@ -237,9 +237,16 @@ _cw_main() {
       local plugins=$(jq -r '.enabledPlugins | keys[]' "$settings_file" 2>/dev/null)
       if [[ -n "$plugins" ]]; then
         echo "Refreshing plugin cache..."
+        # Clear constellos plugin cache to ensure fresh install
+        rm -rf ~/.claude/plugins/cache/constellos/* 2>/dev/null || true
         while IFS= read -r plugin; do
+          # Extract plugin name for verbose output
+          local plugin_name="${plugin%@*}"
+          echo "Installing plugin \"${plugin_name}\"..."
           claude plugin uninstall --scope project "$plugin" 2>/dev/null || true
-          claude plugin install --scope project "$plugin" 2>/dev/null || true
+          claude plugin install --scope project "$plugin" 2>/dev/null && \
+            echo "✔ Successfully installed plugin: ${plugin_name} (scope: project)" || \
+            echo "✘ Failed to install plugin: ${plugin_name}"
         done <<< "$plugins"
       fi
     fi

--- a/plugins/nextjs-supabase-ai-sdk-dev/.claude-plugin/plugin.json
+++ b/plugins/nextjs-supabase-ai-sdk-dev/.claude-plugin/plugin.json
@@ -15,11 +15,11 @@
     },
     "shadcn": {
       "command": "npx",
-      "args": ["-y", "@anthropics/shadcn-mcp@latest"]
+      "args": ["-y", "mcp-remote@latest", "https://ui.shadcn.com/docs/mcp"]
     },
     "ai-elements": {
       "command": "npx",
-      "args": ["-y", "@anthropics/ai-elements-mcp@latest"]
+      "args": ["-y", "mcp-remote@latest", "https://registry.ai-sdk.dev/api/mcp"]
     },
     "supabase": {
       "command": "npx",
@@ -27,7 +27,7 @@
     },
     "vercel": {
       "command": "npx",
-      "args": ["-y", "mcp-handler@latest"]
+      "args": ["-y", "mcp-remote@latest", "https://mcp.vercel.com"]
     }
   }
 }

--- a/plugins/project-context/CLAUDE.md
+++ b/plugins/project-context/CLAUDE.md
@@ -15,12 +15,11 @@ folder:
 
 ## Quick Reference
 
-**Purpose**: Automatically discovers and links CLAUDE.md documentation, validates .claude directory structure, enforces plan-based path scoping, and provides intelligent URL redirection to prefer markdown documentation.
+**Purpose**: Automatically discovers and links CLAUDE.md documentation, validates .claude directory structure, and provides intelligent URL redirection to prefer markdown documentation.
 
 **When to use**:
 - Large codebases requiring organized documentation structure
 - Projects with .claude directory structures (agents, skills, rules, hooks)
-- Plan-driven development workflows with defined scope boundaries
 - Documentation-heavy projects with markdown-friendly docs
 - Teams enforcing consistent project organization standards
 
@@ -36,7 +35,6 @@ folder:
 | try-markdown-page | PreToolUse[WebFetch] | No | Redirects WebFetch to markdown versions of documentation |
 | log-task-result | PostToolUse[Task] | No | Logs Task tool results after agent completion |
 | create-plan-symlink | PostToolUse[Write\|Edit] | No | Creates PLAN.md symlink when plan files are written |
-| enforce-plan-scoping | PostToolUse[Write\|Edit\|Read] | Conditional | Enforces plan-based path scoping (blocks writes, warns on reads) |
 | add-folder-context | PostToolUse[Read] | No | Discovers and adds CLAUDE.md context when reading files |
 
 ## Key Features
@@ -49,9 +47,6 @@ Redirects WebFetch to markdown versions of documentation when available. Prefers
 
 ### Structure Validation
 Validates .claude directory structure ensuring proper organization for agents, skills, rules, and hooks. Blocks operations that would create invalid folder hierarchies.
-
-### Plan Scoping
-Enforces file operation boundaries based on plan frontmatter (`paths` field). Blocks writes outside scope, warns on reads. Helps manage context and separate concerns in large projects.
 
 ### Rules Validation
 Ensures rule files have proper structure with "Required Skills:" heading and valid frontmatter. Integrates with existing validation hooks.
@@ -78,7 +73,6 @@ Add to `.claude/settings.json`:
 DEBUG=* claude                           # All hooks
 DEBUG=encourage-context-review claude    # Context encouragement
 DEBUG=add-folder-context claude          # Context discovery
-DEBUG=enforce-plan-scoping claude        # Plan scoping
 DEBUG=validate-folder-structure claude   # Structure validation
 DEBUG=try-markdown-page claude           # Markdown preference
 ```

--- a/plugins/project-context/hooks/hooks.json
+++ b/plugins/project-context/hooks/hooks.json
@@ -88,11 +88,6 @@
           "type": "command",
           "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/create-plan-symlink.ts",
           "description": "Creates PLAN.md symlink when plan files are written. Maintains active plan reference."
-        },
-        {
-          "type": "command",
-          "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/shared/hooks/enforce-plan-scoping.ts",
-          "description": "Enforces plan-based path scoping for writes/edits. Denies operations outside allowed scope."
         }
       ]
     },
@@ -103,11 +98,6 @@
           "type": "command",
           "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/add-folder-context.ts",
           "description": "Discovers and adds CLAUDE.md context when reading files. Automatically enriches Claude's context with folder-level documentation."
-        },
-        {
-          "type": "command",
-          "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/shared/hooks/enforce-plan-scoping.ts",
-          "description": "Warns when reads are outside plan scope. Non-blocking guidance to stay within plan boundaries."
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Remove `enforce-plan-scoping.ts` references from project-context hooks.json (file was never created, causing `ERR_MODULE_NOT_FOUND` errors in worktrees)
- Update project-context CLAUDE.md to remove enforce-plan-scoping from documentation
- Update MCP servers in nextjs-supabase-ai-sdk-dev to use `mcp-remote`:
  - vercel: `https://mcp.vercel.com`
  - shadcn: `https://ui.shadcn.com/docs/mcp`
  - ai-elements: `https://registry.ai-sdk.dev/api/mcp`
- Fix claude-worktree.sh to explicitly clear `~/.claude/plugins/cache/constellos/` before reinstalling plugins (prevents stale hook references)

## Test plan
- [ ] Create a new worktree with `cw` command
- [ ] Verify no `ERR_MODULE_NOT_FOUND` errors for enforce-plan-scoping.ts
- [ ] Verify plugins are reinstalled with fresh cache
- [ ] Verify MCP servers work with new URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)