### PR TITLE
fix: update Supabase MCP to remote URL and remove non-working shadcn MCP

### DIFF
--- a/plugins/nextjs-supabase-ai-sdk-dev/.claude-plugin/plugin.json
+++ b/plugins/nextjs-supabase-ai-sdk-dev/.claude-plugin/plugin.json
@@ -13,17 +13,13 @@
       "command": "npx",
       "args": ["-y", "next-devtools-mcp@latest"]
     },
-    "shadcn": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote@latest", "https://ui.shadcn.com/docs/mcp"]
-    },
     "ai-elements": {
       "command": "npx",
       "args": ["-y", "mcp-remote@latest", "https://registry.ai-sdk.dev/api/mcp"]
     },
     "supabase": {
       "command": "npx",
-      "args": ["-y", "@supabase/mcp-server-supabase@latest", "--access-token", "${SUPABASE_ACCESS_TOKEN}"]
+      "args": ["-y", "mcp-remote@latest", "https://mcp.supabase.com/mcp"]
     },
     "vercel": {
       "command": "npx",


### PR DESCRIPTION
## Summary

- Updates Supabase MCP in nextjs-supabase-ai-sdk-dev plugin to use remote URL `https://mcp.supabase.com/mcp`
- Removes shadcn MCP which was not working

## Changes

- **Supabase MCP**: Changed from local npx package (`@supabase/mcp-server-supabase@latest` with access token) to remote endpoint via mcp-remote
- **shadcn MCP**: Removed entirely (endpoint `https://ui.shadcn.com/docs/mcp` not working)

## Verification

Confirmed all 27 hooks across all plugins use `npx tsx` (not just `tsx`).

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)