### PR TITLE
fix: nextjs-supabase-ai-sdk-dev plugin paths and add shadcn MCP

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://code.claude.com/schemas/marketplace-schema.json",
-  "name": "constellos",
+  "name": "constellos-local",
   "version": "1.0.0",
   "owner": {
     "name": "constellos"
@@ -23,7 +23,7 @@
     {
       "name": "nextjs-supabase-ai-sdk-dev",
       "description": "Next.js, Supabase, and AI SDK development utilities",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "author": {
         "name": "constellos"
       },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -90,11 +90,12 @@
   },
   "enabledPlugins": {
     "plugin-dev@claude-code-plugins": true,
-    "github-context@constellos": true,
-    "project-context@constellos": true
+    "github-context@constellos-local": true,
+    "project-context@constellos-local": true,
+    "nextjs-supabase-ai-sdk-dev@constellos-local": true
   },
   "extraKnownMarketplaces": {
-    "constellos": {
+    "constellos-local": {
       "source": {
         "source": "directory",
         "path": "${CLAUDE_PROJECT_DIR}/.claude-plugin"

--- a/plugins/nextjs-supabase-ai-sdk-dev/.claude-plugin/plugin.json
+++ b/plugins/nextjs-supabase-ai-sdk-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-supabase-ai-sdk-dev",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Next.js, Supabase, and AI SDK development utilities and hooks",
   "author": {
     "name": "constellos"
@@ -24,6 +24,10 @@
     "vercel": {
       "command": "npx",
       "args": ["-y", "mcp-remote@latest", "https://mcp.vercel.com"]
+    },
+    "shadcn": {
+      "command": "npx",
+      "args": ["shadcn@latest", "mcp"]
     }
   }
 }

--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/hooks.json
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/hooks.json
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx ${CLAUDE_PROJECT_DIR}/shared/hooks/log-task-call.ts",
+            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/shared/hooks/log-task-call.ts",
             "description": "Logs Task tool calls before agent execution. Saves context for later retrieval in SubagentStop hooks."
           }
         ]
@@ -42,7 +42,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx ${CLAUDE_PROJECT_DIR}/shared/hooks/log-task-result.ts",
+            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/shared/hooks/log-task-result.ts",
             "description": "Logs Task tool results after agent completion. Captures agent output and context for analysis."
           },
           {


### PR DESCRIPTION
## Summary
- Fix hooks.json paths: `CLAUDE_PROJECT_DIR` → `CLAUDE_PLUGIN_ROOT` for shared hooks
- Add shadcn MCP to plugin.json mcpServers
- Bump version to 0.1.3
- Rename local marketplace to `constellos-local` for local development

## Test plan
- [x] Verified hooks.json has correct `CLAUDE_PLUGIN_ROOT` paths in cache
- [x] Verified shadcn MCP config is correct: `["shadcn@latest", "mcp"]`
- [x] Verified `claude mcp list` shows all 6 MCP servers connected (including shadcn)
- [ ] Test in lazyjobs project after merge

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)