### PR TITLE
fix: clear ALL plugin caches in worktree script

### DIFF
--- a/claude-worktree.sh
+++ b/claude-worktree.sh
@@ -327,8 +327,8 @@ _cw_main() {
       local plugins=$(jq -r '.enabledPlugins | keys[]' "$settings_file" 2>/dev/null)
       if [[ -n "$plugins" ]]; then
         echo "Refreshing plugin cache..."
-        # Clear constellos plugin cache to ensure fresh install
-        rm -rf ~/.claude/plugins/cache/constellos/* 2>/dev/null || true
+        # Clear ALL plugin caches to ensure fresh install
+        rm -rf ~/.claude/plugins/cache/* 2>/dev/null || true
         while IFS= read -r plugin; do
           # Extract plugin name for verbose output
           local plugin_name="${plugin%@*}"


### PR DESCRIPTION
## Summary
- Fixed worktree script to clear ALL plugin caches (`~/.claude/plugins/cache/*`) instead of just `constellos/`
- Plugin caches may be stored under different directory names depending on installation method (e.g., `claude-code-plugins/` for local installs)
- This fixes broken hook references when using `cw` with repos that have different marketplace configurations

## Test plan
- [ ] Run `cw lazyjobs` and verify plugins install correctly
- [ ] Verify no `ERR_MODULE_NOT_FOUND` errors for hook files

🤖 Generated with [Claude Code](https://claude.com/claude-code)