### PR TITLE
fix: clear only per-plugin cache instead of global cache

### DIFF
--- a/claude-worktree.sh
+++ b/claude-worktree.sh
@@ -327,12 +327,13 @@ _cw_main() {
       local plugins=$(jq -r '.enabledPlugins | keys[]' "$settings_file" 2>/dev/null)
       if [[ -n "$plugins" ]]; then
         echo "Refreshing plugin cache..."
-        # Clear ALL plugin caches to ensure fresh install
-        rm -rf ~/.claude/plugins/cache/* 2>/dev/null || true
         while IFS= read -r plugin; do
-          # Extract plugin name for verbose output
+          # Extract plugin name and marketplace from "plugin-name@marketplace"
           local plugin_name="${plugin%@*}"
+          local marketplace="${plugin#*@}"
           echo "Installing plugin \"${plugin_name}\"..."
+          # Clear only this specific plugin's cache (not other plugins/sessions)
+          rm -rf ~/.claude/plugins/cache/"${marketplace}"/"${plugin_name}" 2>/dev/null || true
           claude plugin uninstall --scope project "$plugin" 2>/dev/null || true
           claude plugin install --scope project "$plugin" 2>/dev/null && \
             echo "✔ Successfully installed plugin: ${plugin_name} (scope: project)" || \


### PR DESCRIPTION
## Summary

- Fixes plugin cache clearing in `claude-worktree.sh` that was breaking concurrent sessions
- Now clears only the specific plugin's cache directory (`~/.claude/plugins/cache/{marketplace}/{plugin-name}/`) instead of the entire cache
- Allows same-version plugin updates while not affecting other plugins or sessions

## Problem

The worktree script was running `rm -rf ~/.claude/plugins/cache/*` which deleted cached plugins that other running Claude Code sessions depend on, causing `ERR_MODULE_NOT_FOUND` errors.

## Solution

Clear only the specific plugin being reinstalled:
```bash
rm -rf ~/.claude/plugins/cache/"${marketplace}"/"${plugin_name}" 2>/dev/null || true
```

## Test plan

- [ ] Start Session A with `cw repo1`
- [ ] In another terminal, start Session B with `cw repo2`
- [ ] Verify Session A's hooks still work
- [ ] Verify Session B's plugins installed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)