### PR TITLE
fix: skip Stop hook in plan mode and improve marketplace registration

### DIFF
--- a/plugins/github-context/hooks/commit-session-check-pr-status.ts
+++ b/plugins/github-context/hooks/commit-session-check-pr-status.ts
@@ -1080,6 +1080,11 @@ Please resolve this before ending the session.`;
 async function handler(input: StopInput): Promise<StopHookOutput> {
   const logger = createDebugLogger(input.cwd, 'commit-session-check-pr-status', true);
 
+  // Skip blocking behavior in plan mode - Claude is just exploring/planning
+  if (input.permission_mode === 'plan') {
+    return { decision: 'approve' };
+  }
+
   try {
     await logger.logInput({ session_id: input.session_id });
 


### PR DESCRIPTION
## Summary
- Skip Stop hook blocking behavior in plan mode (`permission_mode === 'plan'`)
- Improve worktree script marketplace registration with verification and cache clearing

## Changes

### Stop Hook Fix (`plugins/github-context/hooks/commit-session-check-pr-status.ts`)
- Added early return when `permission_mode === 'plan'` to skip all blocking behavior
- Prevents unnecessary blocking during exploration/planning phases

### Worktree Script Improvements (`claude-worktree.sh`)
- Add path verification before/after marketplace registration
- Clear `constellos-local` cache when switching worktrees to prevent stale hooks
- Better error messaging and verification of marketplace updates
- Skip re-registration if marketplace already points to correct worktree

## Test plan
- [ ] Run `cw claude-code-plugins` and verify plugins install successfully
- [ ] Verify `claude plugin marketplace list` shows correct worktree path
- [ ] Enter plan mode and verify Stop hook approves without blocking
- [ ] Exit plan mode and verify Stop hook blocking still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)