### PR TITLE
Switch CI to composite actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,19 @@ on:
 
 jobs:
   Lint:
-    name: Lint
-    uses: constellos/.github/.github/workflows/reusable-lint.yml@main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: constellos/.github/actions/lint@main
 
   Typecheck:
-    name: Typecheck
-    uses: constellos/.github/.github/workflows/reusable-typecheck.yml@main
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: constellos/.github/actions/typecheck@main
 
-  Unit-Tests-Pass:
-    name: Unit Tests Pass
-    uses: constellos/.github/.github/workflows/reusable-unit-tests.yml@main
+  Unit-Tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: constellos/.github/actions/unit-tests@main


### PR DESCRIPTION
## Summary
- Switches from reusable workflows to org-level composite actions
- Status check names will be cleaner: `Lint` instead of `Lint / Lint`

## Changes
- `Lint` job uses `constellos/.github/actions/lint@main`
- `Typecheck` job uses `constellos/.github/actions/typecheck@main`
- `Unit-Tests` job uses `constellos/.github/actions/unit-tests@main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)