### PR TITLE
fix(github-context): remove session label from auto-created issues

### DIFF
--- a/plugins/github-context/hooks/create-issue-on-prompt.ts
+++ b/plugins/github-context/hooks/create-issue-on-prompt.ts
@@ -285,7 +285,7 @@ ${input.prompt}
 *Issue created automatically on first user prompt.*`;
 
     const result = await execGhWithStdin(
-      ['issue', 'create', '--title', title, '--body-file', '-', '--label', 'session'],
+      ['issue', 'create', '--title', title, '--body-file', '-'],
       body,
       input.cwd
     );


### PR DESCRIPTION
## Summary

- Removes the `--label session` argument from the `gh issue create` command in `create-issue-on-prompt.ts`
- Fixes issue creation failing when the "session" label doesn't exist in the repository

## Test plan

- [x] ESLint passes
- [x] TypeScript type checking passes
- [ ] Create a new worktree session and verify issue is created without errors

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)