### PR TITLE
fix: frontmatter parser quote stripping and glob pattern matching

### DIFF
--- a/plugins/project-context/shared/hooks/utils/frontmatter.ts
+++ b/plugins/project-context/shared/hooks/utils/frontmatter.ts
@@ -94,7 +94,7 @@ function parseSimpleYaml(yaml: string): Record<string, unknown> {
     // Handle inline array: [item1, item2]
     if (value.startsWith('[') && value.endsWith(']')) {
       const arrayContent = value.slice(1, -1);
-      data[key] = arrayContent.split(',').map(item => item.trim());
+      data[key] = arrayContent.split(',').map(item => parseValue(item.trim()));
       i++;
       continue;
     }

--- a/shared/hooks/utils/frontmatter.ts
+++ b/shared/hooks/utils/frontmatter.ts
@@ -94,7 +94,7 @@ function parseSimpleYaml(yaml: string): Record<string, unknown> {
     // Handle inline array: [item1, item2]
     if (value.startsWith('[') && value.endsWith(']')) {
       const arrayContent = value.slice(1, -1);
-      data[key] = arrayContent.split(',').map(item => item.trim());
+      data[key] = arrayContent.split(',').map(item => parseValue(item.trim()));
       i++;
       continue;
     }


### PR DESCRIPTION
## Summary

Fixed two bugs in the rule-based check system that prevented checks from running:

- **Frontmatter parser quote stripping** - Array items like `["**/temp-test-*.tsx"]` were not having quotes stripped, causing glob patterns to include literal quote characters
- **Glob pattern matching** - Pattern `**/file.tsx` didn't match files at root level due to regex construction issues

## Changes

### `shared/hooks/utils/frontmatter.ts`
- Added `parseValue()` call when parsing inline array items to strip quotes

### `shared/hooks/run-rule-checks.ts`
- Use string placeholders (`<<<DSS>>>`, `<<<DS>>>`) instead of `\x00`/`\x01` for `**/` and `**` patterns
- Fixed order of operations: `?` → `.` replacement now happens BEFORE restoring placeholders (prevents corrupting `(?:` and `)?` in regex)

## Testing

Created a test rule with `globs: ["**/temp-test-*.tsx"]` and verified:
1. Globs correctly parsed without quotes: `['**/temp-test-*.tsx']`
2. Regex correctly built: `/^(?:.*\/)?temp-test-[^/]*\.tsx$/`
3. File `temp-test-bad.tsx` at root level matches
4. Hook blocks with lint/typecheck errors

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)