### PR TITLE
feat(project-context): separate check hooks for lint, vitest, and typecheck

### DIFF
--- a/plugins/project-context/CLAUDE.md
+++ b/plugins/project-context/CLAUDE.md
@@ -26,8 +26,11 @@ Automatic CLAUDE.md discovery, .claude structure validation, and rule-based chec
 | validate-folder-structure-mkdir | PreToolUse[Bash] | Yes | Validates mkdir commands |
 | try-markdown-page | PreToolUse[WebFetch] | No | Redirects to .md URLs |
 | log-task-result | PostToolUse[Task] | No | Logs task results |
-| run-rule-checks | PostToolUse[Write\|Edit] | Yes | Runs lint/typecheck/vitest |
+| run-file-eslint | PostToolUse[Write\|Edit] | Yes | Runs ESLint on edited files |
+| run-file-vitests | PostToolUse[Write\|Edit] | No | Runs related tests (warns only) |
 | add-folder-context | PostToolUse[Read] | No | Discovers CLAUDE.md files |
+| run-task-vitests | SubagentStop | Yes | Runs tests for all task edits |
+| run-task-typechecks | SubagentStop | Yes | Runs tsc --noEmit after task |
 
 ## Skills
 

--- a/plugins/project-context/hooks/hooks.json
+++ b/plugins/project-context/hooks/hooks.json
@@ -70,6 +70,22 @@
       ]
     }
   ],
+  "SubagentStop": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/run-task-vitests.ts",
+          "description": "Runs vitest for all files edited during the agent's task. Blocking on failure, 500 char limit."
+        },
+        {
+          "type": "command",
+          "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/run-task-typechecks.ts",
+          "description": "Runs tsc --noEmit after agent completes. Blocking on type errors, 500 char limit."
+        }
+      ]
+    }
+  ],
   "PostToolUse": [
     {
       "matcher": "Task",
@@ -86,8 +102,13 @@
       "hooks": [
         {
           "type": "command",
-          "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/shared/hooks/run-rule-checks.ts",
-          "description": "Runs checks defined in .claude/rules/*.md frontmatter (lint, typecheck, vitest). Blocking on failure, 500 char limit."
+          "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/run-file-eslint.ts",
+          "description": "Runs ESLint on edited .ts/.tsx/.js/.jsx files. Blocking on errors, 500 char limit."
+        },
+        {
+          "type": "command",
+          "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/run-file-vitests.ts",
+          "description": "Runs related vitest tests for edited files. Non-blocking (warns only), 500 char limit."
         }
       ]
     },

--- a/plugins/project-context/hooks/run-file-eslint.ts
+++ b/plugins/project-context/hooks/run-file-eslint.ts
@@ -1,0 +1,98 @@
+/**
+ * ESLint check for PostToolUse[Write|Edit] hooks
+ *
+ * Runs eslint on the edited file and blocks if there are errors.
+ * Only runs on .ts, .tsx, .js, .jsx files.
+ *
+ * @module run-file-eslint
+ */
+
+import type { PostToolUseInput, PostToolUseHookOutput } from '../shared/types/types.js';
+import { runHook } from '../shared/hooks/utils/io.js';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+/** Maximum characters for check output to prevent context bloat */
+const MAX_OUTPUT_CHARS = 500;
+
+/** Timeout for eslint in milliseconds (30 seconds) */
+const TIMEOUT_MS = 30000;
+
+/** File extensions to lint */
+const LINT_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx'];
+
+/**
+ * Truncate output to MAX_OUTPUT_CHARS
+ */
+function truncateOutput(output: string): string {
+  if (output.length <= MAX_OUTPUT_CHARS) {
+    return output;
+  }
+
+  const truncated = output.slice(0, MAX_OUTPUT_CHARS);
+  const remaining = output.length - MAX_OUTPUT_CHARS;
+  return `${truncated}\n... (${remaining} more chars truncated)`;
+}
+
+/**
+ * Check if file should be linted based on extension
+ */
+function shouldLint(filePath: string): boolean {
+  return LINT_EXTENSIONS.some((ext) => filePath.endsWith(ext));
+}
+
+/**
+ * PostToolUse[Write|Edit] hook handler
+ *
+ * Runs eslint on the edited file. Blocks if eslint fails.
+ */
+async function handler(input: PostToolUseInput): Promise<PostToolUseHookOutput> {
+  // Only process Write and Edit tools
+  if (input.tool_name !== 'Write' && input.tool_name !== 'Edit') {
+    return {};
+  }
+
+  // Get file path from tool input
+  const toolInput = input.tool_input as { file_path?: string };
+  const filePath = toolInput?.file_path;
+
+  if (!filePath || !shouldLint(filePath)) {
+    return {};
+  }
+
+  // Run eslint
+  const command = `npx eslint --max-warnings 0 "${filePath}"`;
+
+  try {
+    await execAsync(command, {
+      cwd: input.cwd,
+      timeout: TIMEOUT_MS,
+    });
+
+    // ESLint passed
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext: `✓ ESLint passed`,
+      },
+    };
+  } catch (error) {
+    // ESLint failed
+    const err = error as { stdout?: string; stderr?: string; message?: string };
+    const output = err.stdout || err.stderr || err.message || 'ESLint failed';
+
+    return {
+      decision: 'block',
+      reason: `Fix ESLint errors before continuing:\n\n${truncateOutput(output)}`,
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext: `❌ ESLint failed:\n\n${truncateOutput(output)}`,
+      },
+    };
+  }
+}
+
+export { handler };
+runHook(handler);

--- a/plugins/project-context/hooks/run-file-vitests.ts
+++ b/plugins/project-context/hooks/run-file-vitests.ts
@@ -1,0 +1,139 @@
+/**
+ * Vitest check for PostToolUse[Write|Edit] hooks
+ *
+ * Runs vitest for related tests when a file is edited.
+ * Non-blocking - only warns if tests fail.
+ * Only runs on .ts, .tsx files.
+ *
+ * @module run-file-vitests
+ */
+
+import type { PostToolUseInput, PostToolUseHookOutput } from '../shared/types/types.js';
+import { runHook } from '../shared/hooks/utils/io.js';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { access } from 'fs/promises';
+import { basename, dirname, join } from 'path';
+
+const execAsync = promisify(exec);
+
+/** Maximum characters for check output to prevent context bloat */
+const MAX_OUTPUT_CHARS = 500;
+
+/** Timeout for vitest in milliseconds (30 seconds) */
+const TIMEOUT_MS = 30000;
+
+/** File extensions to check for tests */
+const TEST_EXTENSIONS = ['.ts', '.tsx'];
+
+/**
+ * Truncate output to MAX_OUTPUT_CHARS
+ */
+function truncateOutput(output: string): string {
+  if (output.length <= MAX_OUTPUT_CHARS) {
+    return output;
+  }
+
+  const truncated = output.slice(0, MAX_OUTPUT_CHARS);
+  const remaining = output.length - MAX_OUTPUT_CHARS;
+  return `${truncated}\n... (${remaining} more chars truncated)`;
+}
+
+/**
+ * Check if file should have tests checked
+ */
+function shouldCheckTests(filePath: string): boolean {
+  // Don't run tests for test files themselves
+  if (filePath.includes('.test.') || filePath.includes('.spec.')) {
+    return false;
+  }
+  return TEST_EXTENSIONS.some((ext) => filePath.endsWith(ext));
+}
+
+/**
+ * Find the test file for a given source file
+ * Looks for foo.test.ts or foo.test.tsx next to the source file
+ */
+async function findTestFile(filePath: string): Promise<string | null> {
+  const dir = dirname(filePath);
+  const base = basename(filePath);
+
+  // Remove extension to get base name
+  const extMatch = base.match(/\.(ts|tsx)$/);
+  if (!extMatch) return null;
+
+  const nameWithoutExt = base.slice(0, -extMatch[0].length);
+
+  // Try .test.ts and .test.tsx
+  for (const ext of ['.test.ts', '.test.tsx']) {
+    const testPath = join(dir, nameWithoutExt + ext);
+    try {
+      await access(testPath);
+      return testPath;
+    } catch {
+      // File doesn't exist
+    }
+  }
+
+  return null;
+}
+
+/**
+ * PostToolUse[Write|Edit] hook handler
+ *
+ * Runs vitest for related tests. Non-blocking - warns only.
+ */
+async function handler(input: PostToolUseInput): Promise<PostToolUseHookOutput> {
+  // Only process Write and Edit tools
+  if (input.tool_name !== 'Write' && input.tool_name !== 'Edit') {
+    return {};
+  }
+
+  // Get file path from tool input
+  const toolInput = input.tool_input as { file_path?: string };
+  const filePath = toolInput?.file_path;
+
+  if (!filePath || !shouldCheckTests(filePath)) {
+    return {};
+  }
+
+  // Find related test file
+  const testFile = await findTestFile(filePath);
+
+  if (!testFile) {
+    // No test file found, skip silently
+    return {};
+  }
+
+  // Run vitest for the test file
+  const command = `npx vitest run "${testFile}" --reporter=verbose`;
+
+  try {
+    await execAsync(command, {
+      cwd: input.cwd,
+      timeout: TIMEOUT_MS,
+    });
+
+    // Tests passed
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext: `✓ Tests passed for ${basename(testFile)}`,
+      },
+    };
+  } catch (error) {
+    // Tests failed - warn but don't block
+    const err = error as { stdout?: string; stderr?: string; message?: string };
+    const output = err.stdout || err.stderr || err.message || 'Tests failed';
+
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext: `⚠️ Tests failed for ${basename(testFile)}:\n\n${truncateOutput(output)}`,
+      },
+    };
+  }
+}
+
+export { handler };
+runHook(handler);

--- a/plugins/project-context/hooks/run-task-typechecks.ts
+++ b/plugins/project-context/hooks/run-task-typechecks.ts
@@ -1,0 +1,114 @@
+/**
+ * TypeScript check for SubagentStop hooks
+ *
+ * Runs tsc --noEmit on the project after a subagent completes.
+ * Blocks if there are type errors.
+ *
+ * @module run-task-typechecks
+ */
+
+import type { SubagentStopInput, SubagentStopHookOutput } from '../shared/types/types.js';
+import { runHook } from '../shared/hooks/utils/io.js';
+import { getAgentEdits } from '../shared/hooks/utils/subagent-state.js';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+/** Maximum characters for check output to prevent context bloat */
+const MAX_OUTPUT_CHARS = 500;
+
+/** Timeout for tsc in milliseconds (60 seconds - tsc can be slow) */
+const TIMEOUT_MS = 60000;
+
+/** File extensions that trigger typecheck */
+const TS_EXTENSIONS = ['.ts', '.tsx'];
+
+/**
+ * Truncate output to MAX_OUTPUT_CHARS
+ */
+function truncateOutput(output: string): string {
+  if (output.length <= MAX_OUTPUT_CHARS) {
+    return output;
+  }
+
+  const truncated = output.slice(0, MAX_OUTPUT_CHARS);
+  const remaining = output.length - MAX_OUTPUT_CHARS;
+  return `${truncated}\n... (${remaining} more chars truncated)`;
+}
+
+/**
+ * Check if any edited files are TypeScript
+ */
+function hasTypeScriptFiles(files: string[]): boolean {
+  return files.some((file) =>
+    TS_EXTENSIONS.some((ext) => file.endsWith(ext))
+  );
+}
+
+/**
+ * SubagentStop hook handler
+ *
+ * Runs tsc --noEmit on the project. Blocks if typecheck fails.
+ */
+async function handler(input: SubagentStopInput): Promise<SubagentStopHookOutput> {
+  const DEBUG = process.env.DEBUG === '*' || process.env.DEBUG?.includes('task-typechecks');
+
+  if (DEBUG) {
+    console.log('[run-task-typechecks] Hook triggered');
+    console.log('[run-task-typechecks] Agent ID:', input.agent_id);
+  }
+
+  try {
+    // Get all files edited by the agent
+    const edits = await getAgentEdits(input.agent_transcript_path);
+    const allEditedFiles = [...edits.agentNewFiles, ...edits.agentEditedFiles];
+
+    if (DEBUG) {
+      console.log('[run-task-typechecks] Edited files:', allEditedFiles.length);
+    }
+
+    // Only run typecheck if TypeScript files were edited
+    if (!hasTypeScriptFiles(allEditedFiles)) {
+      if (DEBUG) {
+        console.log('[run-task-typechecks] No TypeScript files edited, skipping');
+      }
+      return {};
+    }
+
+    // Run tsc --noEmit on the project
+    const command = 'npx tsc --noEmit';
+
+    if (DEBUG) {
+      console.log('[run-task-typechecks] Running:', command);
+    }
+
+    try {
+      await execAsync(command, {
+        cwd: input.cwd,
+        timeout: TIMEOUT_MS,
+      });
+
+      // Typecheck passed
+      return {};
+    } catch (error) {
+      // Typecheck failed
+      const err = error as { stdout?: string; stderr?: string; message?: string };
+      const output = err.stdout || err.stderr || err.message || 'TypeScript check failed';
+
+      return {
+        decision: 'block',
+        reason: `Fix TypeScript errors before continuing:\n\n${truncateOutput(output)}`,
+      };
+    }
+  } catch (error) {
+    if (DEBUG) {
+      console.error('[run-task-typechecks] Error:', error);
+    }
+    // Don't block on transcript parsing errors
+    return {};
+  }
+}
+
+export { handler };
+runHook(handler);

--- a/plugins/project-context/hooks/run-task-vitests.ts
+++ b/plugins/project-context/hooks/run-task-vitests.ts
@@ -1,0 +1,118 @@
+/**
+ * Vitest check for SubagentStop hooks
+ *
+ * Runs vitest for all files edited during the agent's task.
+ * Blocks if tests fail.
+ *
+ * @module run-task-vitests
+ */
+
+import type { SubagentStopInput, SubagentStopHookOutput } from '../shared/types/types.js';
+import { runHook } from '../shared/hooks/utils/io.js';
+import { getAgentEdits } from '../shared/hooks/utils/subagent-state.js';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+/** Maximum characters for check output to prevent context bloat */
+const MAX_OUTPUT_CHARS = 500;
+
+/** Timeout for vitest in milliseconds (30 seconds) */
+const TIMEOUT_MS = 30000;
+
+/** File extensions to check for tests */
+const TEST_EXTENSIONS = ['.ts', '.tsx'];
+
+/**
+ * Truncate output to MAX_OUTPUT_CHARS
+ */
+function truncateOutput(output: string): string {
+  if (output.length <= MAX_OUTPUT_CHARS) {
+    return output;
+  }
+
+  const truncated = output.slice(0, MAX_OUTPUT_CHARS);
+  const remaining = output.length - MAX_OUTPUT_CHARS;
+  return `${truncated}\n... (${remaining} more chars truncated)`;
+}
+
+/**
+ * Filter to only testable files
+ */
+function getTestableFiles(files: string[]): string[] {
+  return files.filter((file) => {
+    // Skip test files themselves
+    if (file.includes('.test.') || file.includes('.spec.')) {
+      return false;
+    }
+    return TEST_EXTENSIONS.some((ext) => file.endsWith(ext));
+  });
+}
+
+/**
+ * SubagentStop hook handler
+ *
+ * Runs vitest related for all edited files. Blocks if tests fail.
+ */
+async function handler(input: SubagentStopInput): Promise<SubagentStopHookOutput> {
+  const DEBUG = process.env.DEBUG === '*' || process.env.DEBUG?.includes('task-vitests');
+
+  if (DEBUG) {
+    console.log('[run-task-vitests] Hook triggered');
+    console.log('[run-task-vitests] Agent ID:', input.agent_id);
+  }
+
+  try {
+    // Get all files edited by the agent
+    const edits = await getAgentEdits(input.agent_transcript_path);
+    const allEditedFiles = [...edits.agentNewFiles, ...edits.agentEditedFiles];
+    const testableFiles = getTestableFiles(allEditedFiles);
+
+    if (DEBUG) {
+      console.log('[run-task-vitests] Edited files:', allEditedFiles.length);
+      console.log('[run-task-vitests] Testable files:', testableFiles.length);
+    }
+
+    if (testableFiles.length === 0) {
+      // No testable files, skip
+      return {};
+    }
+
+    // Run vitest related for all edited files
+    const filesArg = testableFiles.map((f) => `"${f}"`).join(' ');
+    const command = `npx vitest related ${filesArg} --run --reporter=verbose`;
+
+    if (DEBUG) {
+      console.log('[run-task-vitests] Running:', command);
+    }
+
+    try {
+      await execAsync(command, {
+        cwd: input.cwd,
+        timeout: TIMEOUT_MS,
+      });
+
+      // Tests passed
+      return {};
+    } catch (error) {
+      // Tests failed
+      const err = error as { stdout?: string; stderr?: string; message?: string };
+      const output = err.stdout || err.stderr || err.message || 'Tests failed';
+
+      return {
+        decision: 'block',
+        reason: `Fix test failures before continuing:\n\n${truncateOutput(output)}`,
+      };
+    }
+  } catch (error) {
+    if (DEBUG) {
+      console.error('[run-task-vitests] Error:', error);
+    }
+    // Don't block on transcript parsing errors
+    return {};
+  }
+}
+
+export { handler };
+runHook(handler);


### PR DESCRIPTION
## Summary

- Replace dormant `run-rule-checks.ts` with 4 separate, focused hooks
- Add `run-file-eslint.ts` - PostToolUse hook for file-specific ESLint (blocking)
- Add `run-file-vitests.ts` - PostToolUse hook for related tests (non-blocking, warns only)
- Add `run-task-vitests.ts` - SubagentStop hook for all task edits (blocking)
- Add `run-task-typechecks.ts` - SubagentStop hook for project typecheck (blocking)
- All hooks have 500 char error truncation and 30s timeout (60s for typecheck)

Closes #140

## Test plan

- [x] ESLint passes on all new hook files
- [x] TypeScript compiles without errors
- [x] All 91 existing tests pass
- [ ] Manual test: Edit a .ts file with lint error → verify eslint blocks
- [ ] Manual test: Complete a subagent task → verify typecheck and vitest run

🤖 Generated with [Claude Code](https://claude.com/claude-code)