### PR TITLE
fix(project-context): fix broken imports in use-correct-package-manager hook

### DIFF
--- a/plugins/project-context/.claude-plugin/plugin.json
+++ b/plugins/project-context/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-context",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Project context discovery, markdown-friendly documentation, and maintenance for Claude Code",
   "author": {
     "name": "constellos"

--- a/plugins/project-context/shared/hooks/use-correct-package-manager.ts
+++ b/plugins/project-context/shared/hooks/use-correct-package-manager.ts
@@ -6,9 +6,9 @@
  * @module use-correct-package-manager
  */
 
-import type { PreToolUseInput, PreToolUseHookOutput } from '../../../../shared/types/types.js';
+import type { PreToolUseInput, PreToolUseHookOutput } from '../types/types.js';
 import { runHook } from './utils/io.js';
-import { detectPackageManager } from '../../../../shared/hooks/utils/package-manager.js';
+import { detectPackageManager } from './utils/package-manager.js';
 import { existsSync } from 'fs';
 import { join } from 'path';
 


### PR DESCRIPTION
## Summary

- Fixed broken imports in `use-correct-package-manager.ts` that caused `MODULE_NOT_FOUND` errors
- The hook used `../../../../shared/` paths that work in source but break when plugin is cached
- Changed to use local paths within the plugin's `shared/` folder
- Bumped plugin version to 0.1.3

## Root Cause

When plugins are cached at `~/.claude/plugins/cache/constellos/project-context/0.1.2/`, the `../../../../` import paths traverse outside the cache directory looking for a `shared/` folder that doesn't exist at `~/.claude/plugins/cache/`.

## Test plan

- [x] Typecheck passes
- [ ] Reinstall plugin and verify no `MODULE_NOT_FOUND` errors on Bash commands

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)