### PR TITLE
fix: correct plugin hook import paths for cache compatibility

### DIFF
--- a/plugins/nextjs-supabase-ai-sdk-dev/.claude-plugin/plugin.json
+++ b/plugins/nextjs-supabase-ai-sdk-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-supabase-ai-sdk-dev",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Next.js, Supabase, and AI SDK development utilities and hooks",
   "author": {
     "name": "constellos"

--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/use-proxy-nextjs-16.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/use-proxy-nextjs-16.ts
@@ -6,8 +6,8 @@
  * @module use-proxy-nextjs-16
  */
 
-import type { PreToolUseInput, PreToolUseHookOutput } from '../../../shared/types/types.js';
-import { runHook } from '../../../shared/hooks/utils/io.js';
+import type { PreToolUseInput, PreToolUseHookOutput } from '../shared/types/types.js';
+import { runHook } from '../shared/hooks/utils/io.js';
 import { basename, normalize } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';

--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/validate-supabase-env.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/validate-supabase-env.ts
@@ -5,8 +5,8 @@
  * @module validate-supabase-env
  */
 
-import type { PreToolUseInput, PreToolUseHookOutput } from '../../../shared/types/types.js';
-import { runHook } from '../../../shared/hooks/utils/io.js';
+import type { PreToolUseInput, PreToolUseHookOutput } from '../shared/types/types.js';
+import { runHook } from '../shared/hooks/utils/io.js';
 import { basename } from 'path';
 
 /**

--- a/plugins/project-context/.claude-plugin/plugin.json
+++ b/plugins/project-context/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project-context",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Project context discovery, markdown-friendly documentation, and maintenance for Claude Code",
   "author": {
     "name": "constellos"

--- a/plugins/project-context/hooks/run-file-eslint.ts
+++ b/plugins/project-context/hooks/run-file-eslint.ts
@@ -9,7 +9,7 @@
 
 import type { PostToolUseInput, PostToolUseHookOutput } from '../shared/types/types.js';
 import { runHook } from '../shared/hooks/utils/io.js';
-import { findConfigFile } from '../../../shared/hooks/utils/config-resolver.js';
+import { findConfigFile } from '../shared/hooks/utils/config-resolver.js';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 

--- a/plugins/project-context/hooks/run-file-vitests.ts
+++ b/plugins/project-context/hooks/run-file-vitests.ts
@@ -10,7 +10,7 @@
 
 import type { PostToolUseInput, PostToolUseHookOutput } from '../shared/types/types.js';
 import { runHook } from '../shared/hooks/utils/io.js';
-import { findConfigFile } from '../../../shared/hooks/utils/config-resolver.js';
+import { findConfigFile } from '../shared/hooks/utils/config-resolver.js';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import { access } from 'fs/promises';

--- a/plugins/project-context/hooks/run-task-typechecks.ts
+++ b/plugins/project-context/hooks/run-task-typechecks.ts
@@ -10,7 +10,7 @@
 import type { SubagentStopInput, SubagentStopHookOutput } from '../shared/types/types.js';
 import { runHook } from '../shared/hooks/utils/io.js';
 import { getAgentEdits } from '../shared/hooks/utils/subagent-state.js';
-import { findConfigFile } from '../../../shared/hooks/utils/config-resolver.js';
+import { findConfigFile } from '../shared/hooks/utils/config-resolver.js';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 

--- a/plugins/project-context/hooks/run-task-vitests.ts
+++ b/plugins/project-context/hooks/run-task-vitests.ts
@@ -10,7 +10,7 @@
 import type { SubagentStopInput, SubagentStopHookOutput } from '../shared/types/types.js';
 import { runHook } from '../shared/hooks/utils/io.js';
 import { getAgentEdits } from '../shared/hooks/utils/subagent-state.js';
-import { findConfigFile } from '../../../shared/hooks/utils/config-resolver.js';
+import { findConfigFile } from '../shared/hooks/utils/config-resolver.js';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import * as path from 'path';

--- a/plugins/project-context/shared/hooks/utils/config-resolver.ts
+++ b/plugins/project-context/shared/hooks/utils/config-resolver.ts
@@ -1,0 +1,76 @@
+/**
+ * Configuration File Resolver
+ * Utilities for finding configuration files by traversing parent directories
+ * @module config-resolver
+ */
+
+import { access } from 'fs/promises';
+import * as path from 'path';
+
+/**
+ * Find git repository root directory
+ *
+ * @param startDir - Directory to start searching from
+ * @returns Absolute path to git root, or null if not in a git repository
+ */
+async function findGitRoot(startDir: string): Promise<string | null> {
+  let currentDir = startDir;
+
+  while (true) {
+    try {
+      await access(path.join(currentDir, '.git'));
+      return currentDir;
+    } catch {
+      const parent = path.dirname(currentDir);
+      if (parent === currentDir) return null; // Filesystem root
+      currentDir = parent;
+    }
+  }
+}
+
+/**
+ * Find a configuration file by traversing parent directories
+ *
+ * @param startDir - Directory to start searching from (typically input.cwd)
+ * @param configFileName - Name of config file to find (e.g., 'tsconfig.json')
+ * @param stopAtGitRoot - Whether to stop at git repository root (default: true)
+ * @returns Absolute path to config file directory, or null if not found
+ *
+ * @example
+ * const configDir = await findConfigFile(input.cwd, 'eslint.config.mjs');
+ * if (configDir) {
+ *   await execAsync('npx eslint file.ts', { cwd: configDir });
+ * }
+ */
+export async function findConfigFile(
+  startDir: string,
+  configFileName: string,
+  stopAtGitRoot: boolean = true
+): Promise<string | null> {
+  let currentDir = path.resolve(startDir);
+  const gitRoot = stopAtGitRoot ? await findGitRoot(currentDir) : null;
+
+  while (true) {
+    try {
+      // Check if config file exists in current directory
+      await access(path.join(currentDir, configFileName));
+      return currentDir;
+    } catch {
+      // Config not found in this directory
+    }
+
+    // Check if we should stop at git root
+    if (stopAtGitRoot && gitRoot && currentDir === gitRoot) {
+      return null;
+    }
+
+    // Move to parent directory
+    const parent = path.dirname(currentDir);
+    if (parent === currentDir) {
+      // Reached filesystem root
+      return null;
+    }
+
+    currentDir = parent;
+  }
+}


### PR DESCRIPTION
## Summary

Fixed import paths in 6 hook files that were using global shared folder references (`../../../shared/`) which break when plugins are cached at `~/.claude/plugins/cache/`.

## Changes

### Import Path Fixes
- `nextjs-supabase-ai-sdk-dev/hooks/use-proxy-nextjs-16.ts`
- `nextjs-supabase-ai-sdk-dev/hooks/validate-supabase-env.ts`
- `project-context/hooks/run-file-eslint.ts`
- `project-context/hooks/run-file-vitests.ts`
- `project-context/hooks/run-task-typechecks.ts`
- `project-context/hooks/run-task-vitests.ts`

**Changed from:** `from '../../../shared/hooks/utils/io.js'` (global, breaks in cache)  
**To:** `from '../shared/hooks/utils/io.js'` (plugin-local, works in cache)

### Missing File
- Added `config-resolver.ts` to `project-context/shared/hooks/utils/`

### Version Bumps
- `nextjs-supabase-ai-sdk-dev`: 0.1.3 → 0.1.4
- `project-context`: 0.1.3 → 0.1.4

### Documentation
- Updated `shared/CLAUDE.md` with correct import patterns
- Added clear warning about global vs plugin-local imports
- Explained cache structure and why `../../../shared/` breaks

## Root Cause

When plugins are installed, they're cached at `~/.claude/plugins/cache/{org}/{plugin}/{version}/`. Only the plugin-specific `shared/` folder is copied to cache - the global `shared/` folder at repo root doesn't exist at `~/.claude/plugins/cache/`.

Hooks using `../../../shared/` imports traverse 3 levels up from the plugin cache directory, escaping into a location where `shared/` doesn't exist, causing `MODULE_NOT_FOUND` errors.

**Pattern introduced in:** PR #147  
**Partially fixed in:** PR #151 (missed several hooks)  
**Worktree script:** Working correctly - uninstalls, clears cache, reinstalls. Problem was in source code.

## Test Plan

- [x] Fixed all 6 hooks with wrong import paths
- [x] Verified no remaining `../../../shared/` imports in plugin hooks
- [x] Added missing `config-resolver.ts` to plugin-specific shared folder
- [x] Bumped plugin versions
- [x] Documented correct pattern in `shared/CLAUDE.md`

**To verify fix:**
1. Reinstall plugins with new versions
2. All hooks should execute without MODULE_NOT_FOUND errors

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>