### PR TITLE
Fix dev server startup reliability in nextjs-supabase-ai-sdk-dev plugin

### DIFF
--- a/plugins/nextjs-supabase-ai-sdk-dev/CLAUDE.md
+++ b/plugins/nextjs-supabase-ai-sdk-dev/CLAUDE.md
@@ -20,7 +20,7 @@ Local dev environment setup for Vercel/Supabase and systematic UI development wi
 | Hook | Event | Blocking | Purpose |
 |------|-------|----------|---------|
 | install-vercel | SessionStart | No | Installs Vercel CLI |
-| install-start-supabase-next | SessionStart | No | Sets up Supabase local dev: CLI, Docker, server, env vars, dev server |
+| install-start-supabase-next | SessionStart | No | Sets up Supabase, starts dev servers (Next.js, Cloudflare, Elysia, Turborepo) with health checks and comprehensive logging |
 | log-task-call | PreToolUse[Task] | No | Saves task context |
 | log-task-result | PostToolUse[Task] | No | Logs task results |
 


### PR DESCRIPTION
## Summary

Fixes critical dev server startup failures where servers would not start despite Supabase running and environment variables being saved correctly.

## Changes

### Critical Fixes

1. **Comprehensive Error Logging**
   - Dev server stdout/stderr now logged to `.claude/logs/dev-server-{timestamp}.log`
   - Spawn errors captured and logged immediately
   - Early exits (crashes within 5 seconds) detected and logged
   - Log file paths shown to user on failure

2. **Fixed Turborepo Command Detection**
   - Parses `turbo.json` to check if `dev` task exists
   - Supports both old (`pipeline`) and new (`tasks`) formats
   - Uses `turbo dev` if task defined, falls back to `turbo run dev`
   - Eliminates silent failures from invalid turbo commands

3. **Added Elysia Framework Support**
   - Detects `bun.toml` files
   - Checks `package.json` for `elysia` dependency
   - Uses `bun run dev` as the dev command

4. **Health Checks**
   - Polls `http://localhost:{port}` for up to 10 seconds
   - Verifies server actually responds (not just process spawned)
   - Clear success/failure messages with log paths

5. **Multi-Instance Supabase Warning**
   - Shows which `project_id` is active
   - Non-blocking informational message

## Testing

✅ ESLint passed
✅ TypeScript type checking passed

## Files Changed

- `plugins/nextjs-supabase-ai-sdk-dev/hooks/install-start-supabase-next.ts` (+150 lines)
- `plugins/nextjs-supabase-ai-sdk-dev/CLAUDE.md` (updated hook description)

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)