### PR TITLE
fix: Hook module resolution and install feature-dev plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -90,6 +90,7 @@
   },
   "enabledPlugins": {
     "plugin-dev@claude-code-plugins": true,
+    "feature-dev@claude-code-plugins": true,
     "github-context@constellos-local": true,
     "project-context@constellos-local": true,
     "nextjs-supabase-ai-sdk-dev@constellos-local": true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,36 +1,20 @@
 # Claude Code Plugins
 
-A marketplace of Claude Code plugins with shared TypeScript utilities for typed hooks.
+Plugin marketplace with shared TypeScript utilities for typed hooks.
 
 ## Plugins
 
 | Plugin | Purpose |
 |--------|---------|
-| [github-context](./plugins/github-context/) | GitHub integration, branch context, commit enhancement, CI orchestration |
-| [project-context](./plugins/project-context/) | CLAUDE.md discovery, structure validation, rule-based checks |
-| [nextjs-supabase-ai-sdk-dev](./plugins/nextjs-supabase-ai-sdk-dev/) | Vercel/Supabase CLI, UI development system with 5 skills and 4 agents |
-
-## Architecture
-
-```
-.
-├── .claude-plugin/marketplace.json    # Marketplace definition
-├── shared/                            # Shared utilities
-│   ├── types/types.ts                # Hook type definitions
-│   └── hooks/utils/                  # io, debug, transcripts, etc.
-└── plugins/                          # Individual plugins
-    ├── github-context/
-    ├── project-context/
-    └── nextjs-supabase-ai-sdk-dev/
-```
+| [github-context](./plugins/github-context/) | GitHub integration, branch context, CI |
+| [project-context](./plugins/project-context/) | CLAUDE.md discovery, validation |
+| [nextjs-supabase-ai-sdk-dev](./plugins/nextjs-supabase-ai-sdk-dev/) | Vercel/Supabase, UI dev system |
 
 ## Hook Pattern
 
-All hooks use `runHook` wrapper for stdin/stdout and automatic error handling:
-
 ```typescript
-import type { SessionStartInput, SessionStartHookOutput } from '../../../shared/types/types.js';
-import { runHook } from '../../../shared/hooks/utils/io.js';
+import type { SessionStartInput, SessionStartHookOutput } from '../shared/types/types.js';
+import { runHook } from '../shared/hooks/utils/io.js';
 
 async function handler(input: SessionStartInput): Promise<SessionStartHookOutput> {
   return {
@@ -45,11 +29,12 @@ export { handler };
 runHook(handler);
 ```
 
-## hooks.json Format
+**Important**: Imports use `../shared/` (plugin-local), NOT `../../../shared/` (repo root).
+
+## hooks.json
 
 ```json
 {
-  "description": "My plugin",
   "hooks": {
     "SessionStart": [{ "hooks": [{ "type": "command", "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/my-hook.ts" }] }]
   }
@@ -58,39 +43,21 @@ runHook(handler);
 
 Variables: `${CLAUDE_PROJECT_DIR}`, `${CLAUDE_PLUGIN_ROOT}`
 
-## Creating Plugins
-
-1. Create `plugins/my-plugin/.claude-plugin/plugin.json`
-2. Create `plugins/my-plugin/hooks/hooks.json`
-3. Create hook files in `plugins/my-plugin/hooks/`
-4. Add to `.claude-plugin/marketplace.json`
-5. Create `README.md` with Purpose and Contents sections
-
 ## Installation
 
 ```bash
-claude plugin marketplace add ./
 claude plugin install plugin-name@constellos
 ```
 
 ## Troubleshooting
 
-**Hooks not firing:**
-1. Check `~/.claude/plugins/cache/` for correct hooks.json
-2. Reinstall: `claude plugin uninstall/install --scope project plugin@constellos`
-3. Restart Claude Code session
-
-**Plugin cache stale:**
-```bash
-rm -rf ~/.claude/plugins/cache/constellos
-claude plugin install --scope project plugin-name@constellos
-```
+- **Hooks not firing**: Check `~/.claude/plugins/cache/`, reinstall plugin, restart session
+- **Cache stale**: `rm -rf ~/.claude/plugins/cache/constellos && claude plugin install --scope project`
 
 ## Debug
 
 ```bash
-DEBUG=* claude              # All hooks
-DEBUG=hook-name claude      # Specific hook
+DEBUG=hook-name claude
 ```
 
 Logs: `.claude/logs/hook-events.json`

--- a/plugins/project-context/hooks/add-folder-context.ts
+++ b/plugins/project-context/hooks/add-folder-context.ts
@@ -16,11 +16,11 @@
  * @module add-folder-context
  */
 
-import type { PostToolUseInput, PostToolUseHookOutput } from '../../../shared/types/types.js';
-import { createDebugLogger } from '../../../shared/hooks/utils/debug.js';
-import { runHook } from '../../../shared/hooks/utils/io.js';
-import { parseFileMetadata } from '../../../shared/hooks/utils/tsdoc-parser.js';
-import { loadIndex, saveIndex } from '../../../shared/hooks/utils/metadata-index.js';
+import type { PostToolUseInput, PostToolUseHookOutput } from '../shared/types/types.js';
+import { createDebugLogger } from '../shared/hooks/utils/debug.js';
+import { runHook } from '../shared/hooks/utils/io.js';
+import { parseFileMetadata } from '../shared/hooks/utils/tsdoc-parser.js';
+import { loadIndex, saveIndex } from '../shared/hooks/utils/metadata-index.js';
 import { readdir, access, readFile, writeFile, mkdir, stat } from 'fs/promises';
 import { join, dirname, extname, relative } from 'path';
 import { existsSync } from 'fs';

--- a/plugins/project-context/hooks/track-task-scope.ts
+++ b/plugins/project-context/hooks/track-task-scope.ts
@@ -14,7 +14,7 @@
 import type { PostToolUseInput, PostToolUseHookOutput } from '../shared/types/types.js';
 import { runHook } from '../shared/hooks/utils/io.js';
 import { createDebugLogger } from '../shared/hooks/utils/debug.js';
-import { parsePlanFrontmatter, findTaskByPath } from '../../../shared/hooks/utils/plan-parser.js';
+import { parsePlanFrontmatter, findTaskByPath } from '../shared/hooks/utils/plan-parser.js';
 import { readdir, readFile, stat } from 'fs/promises';
 import { join, relative } from 'path';
 import { existsSync } from 'fs';

--- a/plugins/project-context/shared/hooks/utils/metadata-index.ts
+++ b/plugins/project-context/shared/hooks/utils/metadata-index.ts
@@ -1,0 +1,477 @@
+/**
+ * Metadata Index Manager
+ *
+ * Manages the incremental metadata index stored in `.claude/logs/metadata-index.json`.
+ * Provides functions to load, save, and update file and folder metadata for
+ * context-aware prompt enrichment.
+ *
+ * @module metadata-index
+ */
+
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import type { ExportInfo } from './tsdoc-parser.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const LOGS_DIR = '.claude/logs';
+const INDEX_FILE = 'metadata-index.json';
+const INDEX_VERSION = '1.0.0';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Metadata for an indexed file
+ *
+ * Contains all context information extracted from a TypeScript file
+ * including TSDoc tags, exports, and timing information.
+ */
+export interface FileMetadata {
+  /**
+   * Relative path to the file from project root
+   */
+  path: string;
+  /**
+   * ISO timestamp of last file modification
+   */
+  lastModified: string;
+  /**
+   * ISO timestamp when the file was indexed
+   */
+  lastIndexed: string;
+  /**
+   * Context tags extracted from TSDoc @context and implicit naming
+   */
+  tags: string[];
+  /**
+   * Aliases extracted from TSDoc @aliases
+   */
+  aliases: string[];
+  /**
+   * All exports found in the file
+   */
+  exports: ExportInfo[];
+  /**
+   * File-level description from leading comment
+   */
+  description?: string;
+}
+
+/**
+ * Metadata for an indexed folder
+ *
+ * Contains context information from CLAUDE.md files and
+ * folder-level metadata.
+ */
+export interface FolderMetadata {
+  /**
+   * Relative path to the folder from project root
+   */
+  path: string;
+  /**
+   * Path to the CLAUDE.md file if present
+   */
+  claudeMdPath?: string;
+  /**
+   * Title extracted from CLAUDE.md H1 heading
+   */
+  title?: string;
+  /**
+   * Context tags from CLAUDE.md frontmatter or content
+   */
+  tags: string[];
+  /**
+   * ISO timestamp when the folder was indexed
+   */
+  lastIndexed: string;
+}
+
+/**
+ * Cached Supabase schema information
+ *
+ * Stores table names and columns for database-aware context matching.
+ */
+export interface SupabaseSchemaCache {
+  /**
+   * ISO timestamp when schema was fetched
+   */
+  lastFetched: string;
+  /**
+   * Project ID this schema belongs to
+   */
+  projectId?: string;
+  /**
+   * Table metadata
+   */
+  tables: Array<{
+    /**
+     * Table name
+     */
+    name: string;
+    /**
+     * Schema name (usually 'public')
+     */
+    schema: string;
+    /**
+     * Column names
+     */
+    columns: string[];
+    /**
+     * Primary key column names
+     */
+    primaryKeys: string[];
+  }>;
+}
+
+/**
+ * Complete metadata index
+ *
+ * The root structure for the metadata-index.json file.
+ */
+export interface MetadataIndex {
+  /**
+   * Schema version for forward compatibility
+   */
+  version: string;
+  /**
+   * ISO timestamp of last index update
+   */
+  lastUpdated: string;
+  /**
+   * Map of file paths to their metadata
+   */
+  files: { [filePath: string]: FileMetadata };
+  /**
+   * Map of folder paths to their metadata
+   */
+  folders: { [folderPath: string]: FolderMetadata };
+  /**
+   * Optional Supabase schema cache
+   */
+  supabase?: SupabaseSchemaCache;
+}
+
+// ============================================================================
+// Path Helpers
+// ============================================================================
+
+/**
+ * Get the path to the metadata index file
+ *
+ * @param cwd - The working directory (project root)
+ * @returns Full path to metadata-index.json
+ */
+function getIndexPath(cwd: string): string {
+  return path.join(cwd, LOGS_DIR, INDEX_FILE);
+}
+
+// ============================================================================
+// Index Management
+// ============================================================================
+
+/**
+ * Load the metadata index from disk
+ *
+ * Reads and parses the metadata-index.json file. If the file doesn't exist
+ * or is invalid, returns a fresh empty index.
+ *
+ * @param cwd - The working directory (project root)
+ * @returns The loaded metadata index, or empty index if not found
+ *
+ * @example
+ * ```typescript
+ * import { loadIndex } from './metadata-index.js';
+ *
+ * const index = await loadIndex('/path/to/project');
+ * console.log(`Indexed ${Object.keys(index.files).length} files`);
+ * console.log(`Indexed ${Object.keys(index.folders).length} folders`);
+ * ```
+ */
+export async function loadIndex(cwd: string): Promise<MetadataIndex> {
+  const indexPath = getIndexPath(cwd);
+
+  try {
+    const content = await fs.readFile(indexPath, 'utf-8');
+    const index: MetadataIndex = JSON.parse(content);
+
+    // Validate version
+    if (index.version !== INDEX_VERSION) {
+      // Version mismatch - return fresh index
+      // Future: could implement migrations here
+      return createEmptyIndex();
+    }
+
+    return index;
+  } catch {
+    // File doesn't exist or is invalid
+    return createEmptyIndex();
+  }
+}
+
+/**
+ * Create an empty metadata index
+ *
+ * @returns Fresh metadata index with empty collections
+ */
+function createEmptyIndex(): MetadataIndex {
+  return {
+    version: INDEX_VERSION,
+    lastUpdated: new Date().toISOString(),
+    files: {},
+    folders: {},
+  };
+}
+
+/**
+ * Save the metadata index to disk
+ *
+ * Writes the index to .claude/logs/metadata-index.json, creating
+ * the directory structure if needed.
+ *
+ * @param cwd - The working directory (project root)
+ * @param index - The index to save
+ *
+ * @example
+ * ```typescript
+ * import { loadIndex, saveIndex } from './metadata-index.js';
+ *
+ * const index = await loadIndex(cwd);
+ * index.files['src/auth/login.ts'] = fileMetadata;
+ * await saveIndex(cwd, index);
+ * ```
+ */
+export async function saveIndex(cwd: string, index: MetadataIndex): Promise<void> {
+  const indexPath = getIndexPath(cwd);
+  const indexDir = path.dirname(indexPath);
+
+  // Update timestamp
+  index.lastUpdated = new Date().toISOString();
+
+  // Ensure directory exists
+  await fs.mkdir(indexDir, { recursive: true });
+
+  // Write with pretty formatting for debugging
+  await fs.writeFile(indexPath, JSON.stringify(index, null, 2), 'utf-8');
+}
+
+/**
+ * Update metadata for a single file
+ *
+ * Loads the index, updates the file entry, and saves back to disk.
+ * This is a convenience function for incremental updates.
+ *
+ * @param cwd - The working directory (project root)
+ * @param filePath - Relative path to the file
+ * @param metadata - Updated file metadata
+ *
+ * @example
+ * ```typescript
+ * import { updateFileMetadata } from './metadata-index.js';
+ * import { parseFileMetadata } from './tsdoc-parser.js';
+ *
+ * const content = await fs.readFile('src/auth/login.ts', 'utf-8');
+ * const metadata = parseFileMetadata('src/auth/login.ts', content);
+ * await updateFileMetadata(cwd, 'src/auth/login.ts', metadata);
+ * ```
+ */
+export async function updateFileMetadata(
+  cwd: string,
+  filePath: string,
+  metadata: FileMetadata
+): Promise<void> {
+  const index = await loadIndex(cwd);
+  index.files[filePath] = metadata;
+  await saveIndex(cwd, index);
+}
+
+/**
+ * Update metadata for a single folder
+ *
+ * Loads the index, updates the folder entry, and saves back to disk.
+ * This is a convenience function for incremental updates.
+ *
+ * @param cwd - The working directory (project root)
+ * @param folderPath - Relative path to the folder
+ * @param metadata - Updated folder metadata
+ *
+ * @example
+ * ```typescript
+ * import { updateFolderMetadata } from './metadata-index.js';
+ *
+ * await updateFolderMetadata(cwd, 'src/auth', {
+ *   path: 'src/auth',
+ *   claudeMdPath: 'src/auth/CLAUDE.md',
+ *   title: 'Authentication Module',
+ *   tags: ['authentication', 'security', 'oauth'],
+ *   lastIndexed: new Date().toISOString()
+ * });
+ * ```
+ */
+export async function updateFolderMetadata(
+  cwd: string,
+  folderPath: string,
+  metadata: FolderMetadata
+): Promise<void> {
+  const index = await loadIndex(cwd);
+  index.folders[folderPath] = metadata;
+  await saveIndex(cwd, index);
+}
+
+/**
+ * Remove a file from the index
+ *
+ * Used when a file is deleted or renamed.
+ *
+ * @param cwd - The working directory (project root)
+ * @param filePath - Relative path to the file to remove
+ *
+ * @example
+ * ```typescript
+ * import { removeFileMetadata } from './metadata-index.js';
+ *
+ * // After detecting file deletion
+ * await removeFileMetadata(cwd, 'src/old-file.ts');
+ * ```
+ */
+export async function removeFileMetadata(cwd: string, filePath: string): Promise<void> {
+  const index = await loadIndex(cwd);
+  delete index.files[filePath];
+  await saveIndex(cwd, index);
+}
+
+/**
+ * Remove a folder from the index
+ *
+ * Used when a folder is deleted or renamed.
+ *
+ * @param cwd - The working directory (project root)
+ * @param folderPath - Relative path to the folder to remove
+ *
+ * @example
+ * ```typescript
+ * import { removeFolderMetadata } from './metadata-index.js';
+ *
+ * // After detecting folder deletion
+ * await removeFolderMetadata(cwd, 'src/deprecated');
+ * ```
+ */
+export async function removeFolderMetadata(cwd: string, folderPath: string): Promise<void> {
+  const index = await loadIndex(cwd);
+  delete index.folders[folderPath];
+  await saveIndex(cwd, index);
+}
+
+/**
+ * Update Supabase schema cache
+ *
+ * Stores table metadata for database-aware context matching.
+ *
+ * @param cwd - The working directory (project root)
+ * @param schema - Supabase schema information
+ *
+ * @example
+ * ```typescript
+ * import { updateSupabaseSchema } from './metadata-index.js';
+ *
+ * await updateSupabaseSchema(cwd, {
+ *   lastFetched: new Date().toISOString(),
+ *   projectId: 'abc123',
+ *   tables: [
+ *     { name: 'users', schema: 'public', columns: ['id', 'email'], primaryKeys: ['id'] }
+ *   ]
+ * });
+ * ```
+ */
+export async function updateSupabaseSchema(
+  cwd: string,
+  schema: SupabaseSchemaCache
+): Promise<void> {
+  const index = await loadIndex(cwd);
+  index.supabase = schema;
+  await saveIndex(cwd, index);
+}
+
+/**
+ * Check if a file needs re-indexing
+ *
+ * Compares the file's modification time with the indexed timestamp.
+ *
+ * @param cwd - The working directory (project root)
+ * @param filePath - Relative path to the file
+ * @param lastModified - ISO timestamp of file's current mtime
+ * @returns True if the file should be re-indexed
+ *
+ * @example
+ * ```typescript
+ * import { needsReindex } from './metadata-index.js';
+ * import * as fs from 'fs/promises';
+ *
+ * const stat = await fs.stat('src/auth/login.ts');
+ * const needsUpdate = await needsReindex(cwd, 'src/auth/login.ts', stat.mtime.toISOString());
+ *
+ * if (needsUpdate) {
+ *   // Re-parse and update the file metadata
+ * }
+ * ```
+ */
+export async function needsReindex(
+  cwd: string,
+  filePath: string,
+  lastModified: string
+): Promise<boolean> {
+  const index = await loadIndex(cwd);
+  const existing = index.files[filePath];
+
+  if (!existing) {
+    return true; // Not indexed yet
+  }
+
+  // Compare modification times
+  return new Date(lastModified) > new Date(existing.lastModified);
+}
+
+/**
+ * Get all indexed file paths
+ *
+ * Returns an array of all file paths currently in the index.
+ *
+ * @param cwd - The working directory (project root)
+ * @returns Array of indexed file paths
+ *
+ * @example
+ * ```typescript
+ * import { getIndexedFiles } from './metadata-index.js';
+ *
+ * const files = await getIndexedFiles(cwd);
+ * console.log(`${files.length} files indexed`);
+ * ```
+ */
+export async function getIndexedFiles(cwd: string): Promise<string[]> {
+  const index = await loadIndex(cwd);
+  return Object.keys(index.files);
+}
+
+/**
+ * Get all indexed folder paths
+ *
+ * Returns an array of all folder paths currently in the index.
+ *
+ * @param cwd - The working directory (project root)
+ * @returns Array of indexed folder paths
+ *
+ * @example
+ * ```typescript
+ * import { getIndexedFolders } from './metadata-index.js';
+ *
+ * const folders = await getIndexedFolders(cwd);
+ * console.log(`${folders.length} folders indexed`);
+ * ```
+ */
+export async function getIndexedFolders(cwd: string): Promise<string[]> {
+  const index = await loadIndex(cwd);
+  return Object.keys(index.folders);
+}

--- a/plugins/project-context/shared/hooks/utils/plan-parser.ts
+++ b/plugins/project-context/shared/hooks/utils/plan-parser.ts
@@ -1,0 +1,476 @@
+/**
+ * Plan file parser for task definitions
+ *
+ * Parses YAML frontmatter from plan files to extract task definitions,
+ * including agent assignments, file path patterns, and dependencies.
+ *
+ * Note: This module includes its own YAML parsing for nested task arrays
+ * because the simple frontmatter.ts parser doesn't support multi-line
+ * nested YAML structures.
+ *
+ * @module plan-parser
+ */
+
+// ============================================================================
+// Type Definitions
+// ============================================================================
+
+/**
+ * A task definition within a plan file
+ *
+ * Defines the scope of work for a specific agent, including:
+ * - Which files the agent is responsible for (via glob patterns)
+ * - What requirements the agent must fulfill
+ * - Dependencies on other tasks
+ */
+export interface TaskDefinition {
+  /** Unique identifier for the task within the plan */
+  id: string;
+  /** Agent type assigned to this task (e.g., 'ui-developer', 'api-specialist') */
+  agent: string;
+  /** Glob patterns for files in this task's scope (e.g., 'src/api/**', 'src/components/*.tsx') */
+  paths: string[];
+  /** List of requirements for this task */
+  requirements: string[];
+  /** Optional list of task IDs this task depends on */
+  dependencies?: string[];
+}
+
+/**
+ * Parsed metadata from a plan file's frontmatter
+ */
+export interface PlanMetadata {
+  /** Array of task definitions from the plan */
+  tasks: TaskDefinition[];
+}
+
+/**
+ * Result of task validation
+ */
+export interface ValidationResult {
+  /** Whether all tasks are valid */
+  valid: boolean;
+  /** Array of validation error messages */
+  errors: string[];
+}
+
+// ============================================================================
+// Glob Matching Implementation
+// ============================================================================
+
+/**
+ * Simple glob pattern matching
+ *
+ * Supports:
+ * - `**` for recursive directory matching
+ * - `*` for single path segment matching
+ * - Literal path matching
+ *
+ * @param pattern - Glob pattern to match against
+ * @param path - File path to test
+ * @returns True if the path matches the pattern
+ *
+ * @example
+ * ```typescript
+ * isPathMatch('src/api/**', 'src/api/routes/users.ts'); // true
+ * isPathMatch('src/components/*.tsx', 'src/components/Button.tsx'); // true
+ * isPathMatch('src/components/*.tsx', 'src/components/forms/Input.tsx'); // false
+ * ```
+ */
+function isPathMatch(pattern: string, path: string): boolean {
+  // Normalize both pattern and path (remove leading/trailing slashes)
+  const normalizedPattern = pattern.replace(/^\/+|\/+$/g, '');
+  const normalizedPath = path.replace(/^\/+|\/+$/g, '');
+
+  // Convert glob pattern to regex
+  const regexPattern = normalizedPattern
+    // Escape special regex characters except * and **
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    // Handle ** (recursive match)
+    .replace(/\*\*/g, '<<<DOUBLE_STAR>>>')
+    // Handle * (single segment match - no slashes)
+    .replace(/\*/g, '[^/]*')
+    // Restore ** as match anything
+    .replace(/<<<DOUBLE_STAR>>>/g, '.*');
+
+  const regex = new RegExp(`^${regexPattern}$`);
+  return regex.test(normalizedPath);
+}
+
+// ============================================================================
+// YAML Parsing Helpers
+// ============================================================================
+
+/**
+ * Extract frontmatter content from markdown
+ */
+function extractFrontmatter(content: string): string | null {
+  const match = content.match(/^---\s*\n([\s\S]*?)\n---/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Parse an inline array like [item1, item2, item3]
+ */
+function parseInlineArray(value: string): string[] {
+  if (!value.startsWith('[') || !value.endsWith(']')) {
+    return [];
+  }
+  const inner = value.slice(1, -1).trim();
+  if (!inner) return [];
+
+  return inner.split(',').map((item) => item.trim());
+}
+
+/**
+ * Parse a simple YAML value (string, boolean, number)
+ */
+function parseYamlValue(value: string): string {
+  // Remove surrounding quotes
+  if ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+/**
+ * Parse tasks from YAML frontmatter with proper indentation handling
+ *
+ * Supports the format:
+ * ```yaml
+ * tasks:
+ *   - id: task-name
+ *     agent: agent-type
+ *     paths: [pattern1, pattern2]
+ *     requirements: [req1, req2]
+ *     dependencies: [dep1, dep2]
+ * ```
+ */
+function parseTasksFromYaml(yaml: string): TaskDefinition[] {
+  const lines = yaml.split('\n');
+  const tasks: TaskDefinition[] = [];
+  let currentTask: Partial<TaskDefinition> | null = null;
+
+  // Find the tasks: section
+  let inTasks = false;
+  let taskIndent = 0;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Skip empty lines and comments
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue;
+    }
+
+    // Check for tasks: key
+    if (trimmed === 'tasks:') {
+      inTasks = true;
+      continue;
+    }
+
+    if (!inTasks) {
+      continue;
+    }
+
+    // Check if we've exited the tasks section (less indent than expected)
+    const lineIndent = line.search(/\S/);
+    if (lineIndent >= 0 && !line.startsWith(' ') && !line.startsWith('\t') && !trimmed.startsWith('-')) {
+      // We've hit a new top-level key
+      inTasks = false;
+      continue;
+    }
+
+    // New task item starts with -
+    if (trimmed.startsWith('- ')) {
+      // Save previous task
+      if (currentTask && currentTask.id && currentTask.agent) {
+        tasks.push({
+          id: currentTask.id,
+          agent: currentTask.agent,
+          paths: currentTask.paths || [],
+          requirements: currentTask.requirements || [],
+          dependencies: currentTask.dependencies,
+        });
+      }
+
+      // Start new task
+      currentTask = {};
+      taskIndent = lineIndent;
+
+      // Parse the first property on the same line as -
+      const afterDash = trimmed.slice(2).trim();
+      if (afterDash) {
+        const colonIdx = afterDash.indexOf(':');
+        if (colonIdx > 0) {
+          const key = afterDash.slice(0, colonIdx).trim();
+          const value = afterDash.slice(colonIdx + 1).trim();
+          setTaskProperty(currentTask, key, value);
+        }
+      }
+      continue;
+    }
+
+    // Task property line
+    if (currentTask && lineIndent > taskIndent) {
+      const colonIdx = trimmed.indexOf(':');
+      if (colonIdx > 0) {
+        const key = trimmed.slice(0, colonIdx).trim();
+        const value = trimmed.slice(colonIdx + 1).trim();
+        setTaskProperty(currentTask, key, value);
+      }
+    }
+  }
+
+  // Save last task
+  if (currentTask && currentTask.id && currentTask.agent) {
+    tasks.push({
+      id: currentTask.id,
+      agent: currentTask.agent,
+      paths: currentTask.paths || [],
+      requirements: currentTask.requirements || [],
+      dependencies: currentTask.dependencies,
+    });
+  }
+
+  return tasks;
+}
+
+/**
+ * Set a property on a partial task object
+ */
+function setTaskProperty(task: Partial<TaskDefinition>, key: string, value: string): void {
+  switch (key) {
+    case 'id':
+      task.id = parseYamlValue(value);
+      break;
+    case 'agent':
+      task.agent = parseYamlValue(value);
+      break;
+    case 'paths':
+      task.paths = parseInlineArray(value);
+      break;
+    case 'requirements':
+      task.requirements = parseInlineArray(value);
+      break;
+    case 'dependencies':
+      task.dependencies = parseInlineArray(value);
+      break;
+  }
+}
+
+// ============================================================================
+// Plan Parsing Functions
+// ============================================================================
+
+/**
+ * Parse YAML frontmatter from plan file content to extract task definitions
+ *
+ * Expects plan files with frontmatter in this format:
+ *
+ * ```yaml
+ * ---
+ * tasks:
+ *   - id: api-development
+ *     agent: api-specialist
+ *     paths: [src/api/**, src/lib/api/**]
+ *     requirements: [Implement REST endpoints, Add validation]
+ *     dependencies: [database-setup]
+ * ---
+ * ```
+ *
+ * @param content - Full content of the plan file
+ * @returns Parsed plan metadata with tasks, or null if no valid frontmatter
+ *
+ * @example
+ * ```typescript
+ * const planContent = fs.readFileSync('.claude/plans/feature.md', 'utf-8');
+ * const metadata = parsePlanFrontmatter(planContent);
+ * if (metadata) {
+ *   console.log('Tasks:', metadata.tasks.length);
+ * }
+ * ```
+ */
+export function parsePlanFrontmatter(content: string): PlanMetadata | null {
+  const yaml = extractFrontmatter(content);
+
+  if (!yaml) {
+    return null;
+  }
+
+  const tasks = parseTasksFromYaml(yaml);
+
+  if (tasks.length === 0) {
+    return null;
+  }
+
+  return { tasks };
+}
+
+/**
+ * Validate task definitions for correctness
+ *
+ * Checks:
+ * - All tasks have unique IDs
+ * - All tasks have at least one path pattern
+ * - All dependencies reference existing task IDs
+ * - No circular dependencies
+ *
+ * @param tasks - Array of task definitions to validate
+ * @returns Validation result with success status and any error messages
+ *
+ * @example
+ * ```typescript
+ * const result = validateTaskDefinitions(metadata.tasks);
+ * if (!result.valid) {
+ *   console.error('Validation errors:', result.errors);
+ * }
+ * ```
+ */
+export function validateTaskDefinitions(tasks: TaskDefinition[]): ValidationResult {
+  const errors: string[] = [];
+  const taskIds = new Set<string>();
+
+  // First pass: collect IDs and check for duplicates
+  for (const task of tasks) {
+    if (taskIds.has(task.id)) {
+      errors.push(`Duplicate task ID: '${task.id}'`);
+    }
+    taskIds.add(task.id);
+
+    if (task.paths.length === 0) {
+      errors.push(`Task '${task.id}' has no paths defined`);
+    }
+  }
+
+  // Second pass: validate dependencies
+  for (const task of tasks) {
+    if (task.dependencies) {
+      for (const dep of task.dependencies) {
+        if (!taskIds.has(dep)) {
+          errors.push(`Task '${task.id}' depends on unknown task: '${dep}'`);
+        }
+        if (dep === task.id) {
+          errors.push(`Task '${task.id}' cannot depend on itself`);
+        }
+      }
+    }
+  }
+
+  // Check for circular dependencies
+  const circularErrors = detectCircularDependencies(tasks);
+  errors.push(...circularErrors);
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+/**
+ * Detect circular dependencies in task definitions
+ *
+ * Uses depth-first search to find cycles in the dependency graph.
+ */
+function detectCircularDependencies(tasks: TaskDefinition[]): string[] {
+  const errors: string[] = [];
+  const taskMap = new Map(tasks.map((t) => [t.id, t]));
+  const visited = new Set<string>();
+  const inStack = new Set<string>();
+
+  function dfs(taskId: string, path: string[]): boolean {
+    if (inStack.has(taskId)) {
+      const cycleStart = path.indexOf(taskId);
+      const cycle = [...path.slice(cycleStart), taskId].join(' -> ');
+      errors.push(`Circular dependency detected: ${cycle}`);
+      return true;
+    }
+
+    if (visited.has(taskId)) {
+      return false;
+    }
+
+    visited.add(taskId);
+    inStack.add(taskId);
+
+    const task = taskMap.get(taskId);
+    if (task?.dependencies) {
+      for (const dep of task.dependencies) {
+        if (dfs(dep, [...path, taskId])) {
+          return true;
+        }
+      }
+    }
+
+    inStack.delete(taskId);
+    return false;
+  }
+
+  for (const task of tasks) {
+    if (!visited.has(task.id)) {
+      dfs(task.id, []);
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Find the task definition that owns a given file path
+ *
+ * Searches through all tasks and returns the first task whose path patterns
+ * match the given file path. Returns null if no task matches.
+ *
+ * @param tasks - Array of task definitions to search
+ * @param filePath - File path to find the owning task for
+ * @returns The matching task definition, or null if no match
+ *
+ * @example
+ * ```typescript
+ * const task = findTaskByPath(metadata.tasks, 'src/api/routes/users.ts');
+ * if (task) {
+ *   console.log(`File belongs to task '${task.id}' (agent: ${task.agent})`);
+ * }
+ * ```
+ */
+export function findTaskByPath(tasks: TaskDefinition[], filePath: string): TaskDefinition | null {
+  for (const task of tasks) {
+    if (isPathInScope(task.paths, filePath)) {
+      return task;
+    }
+  }
+  return null;
+}
+
+/**
+ * Check if a file path matches any of the given path patterns
+ *
+ * @param taskPaths - Array of glob patterns to match against
+ * @param filePath - File path to test
+ * @returns True if the file path matches any pattern
+ *
+ * @example
+ * ```typescript
+ * const paths = ['src/api/**', 'src/lib/api/**'];
+ * isPathInScope(paths, 'src/api/routes/users.ts'); // true
+ * isPathInScope(paths, 'src/components/Button.tsx'); // false
+ * ```
+ */
+export function isPathInScope(taskPaths: string[], filePath: string): boolean {
+  return taskPaths.some((pattern) => isPathMatch(pattern, filePath));
+}
+
+/**
+ * Find all tasks whose paths match a given file
+ *
+ * Unlike findTaskByPath which returns the first match, this returns all
+ * matching tasks. Useful for detecting overlapping task scopes.
+ *
+ * @param tasks - Array of task definitions to search
+ * @param filePath - File path to find matching tasks for
+ * @returns Array of all matching task definitions
+ */
+export function findAllTasksByPath(tasks: TaskDefinition[], filePath: string): TaskDefinition[] {
+  return tasks.filter((task) => isPathInScope(task.paths, filePath));
+}

--- a/plugins/project-context/shared/hooks/utils/tsdoc-parser.ts
+++ b/plugins/project-context/shared/hooks/utils/tsdoc-parser.ts
@@ -1,0 +1,485 @@
+/**
+ * TSDoc metadata parser for TypeScript files
+ *
+ * Extracts context metadata from TSDoc comments including @context and @aliases tags,
+ * as well as implicit tags from exported function/component/class names.
+ * Uses regex-based parsing for zero external dependencies.
+ *
+ * @module tsdoc-parser
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Metadata extracted from TSDoc comments
+ *
+ * Contains context tags, aliases, and optional description
+ * extracted from JSDoc-style comments.
+ */
+export interface TSDocMetadata {
+  /**
+   * Context tags from @context (comma-separated values)
+   * @example ['authentication', 'user-management', 'security']
+   */
+  tags: string[];
+  /**
+   * Aliases from @aliases (comma-separated values)
+   * @example ['login', 'signin', 'auth']
+   */
+  aliases: string[];
+  /**
+   * Description extracted from the first line of the comment
+   */
+  description?: string;
+}
+
+/**
+ * Information about an exported item from a TypeScript file
+ *
+ * Captures the name, type, associated TSDoc metadata, and line number
+ * for each export in a file.
+ */
+export interface ExportInfo {
+  /**
+   * Name of the exported item
+   */
+  name: string;
+  /**
+   * Type of export
+   */
+  type: 'function' | 'component' | 'class' | 'constant' | 'type';
+  /**
+   * TSDoc metadata associated with this export
+   */
+  metadata: TSDocMetadata;
+  /**
+   * Line number where the export is defined (1-indexed)
+   */
+  line: number;
+}
+
+/**
+ * Complete metadata for a parsed TypeScript file
+ *
+ * Combines file-level metadata with all export information.
+ */
+export interface FileMetadata {
+  /**
+   * Relative path to the file
+   */
+  path: string;
+  /**
+   * ISO timestamp of last file modification
+   */
+  lastModified: string;
+  /**
+   * ISO timestamp when the file was indexed
+   */
+  lastIndexed: string;
+  /**
+   * Aggregated tags from all exports and file-level comments
+   */
+  tags: string[];
+  /**
+   * Aggregated aliases from all exports and file-level comments
+   */
+  aliases: string[];
+  /**
+   * All exports found in the file
+   */
+  exports: ExportInfo[];
+  /**
+   * File-level description from leading comment
+   */
+  description?: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Regex to match JSDoc-style comments (both block and doc comments)
+ */
+const JSDOC_COMMENT_REGEX = /\/\*\*?([\s\S]*?)\*\//g;
+
+/**
+ * Regex to match @context tag with comma-separated values
+ */
+const CONTEXT_TAG_REGEX = /@context\s+([^\n@]+)/gi;
+
+/**
+ * Regex to match @aliases tag with comma-separated values
+ */
+const ALIASES_TAG_REGEX = /@aliases?\s+([^\n@]+)/gi;
+
+/**
+ * Regex to match first line description (before any @tags)
+ */
+const DESCRIPTION_REGEX = /^\s*\*?\s*([^@\n*][^\n]*)/m;
+
+/**
+ * Regex patterns for different export types
+ */
+const EXPORT_PATTERNS = {
+  // export function name() or export async function name()
+  function: /^export\s+(?:async\s+)?function\s+(\w+)/,
+  // export const Name = () => or export const name =
+  arrowFunction: /^export\s+const\s+(\w+)\s*=\s*(?:\([^)]*\)|[^=])*=>/,
+  // export const name = value (not arrow function)
+  constant: /^export\s+const\s+(\w+)\s*=/,
+  // export class Name
+  class: /^export\s+class\s+(\w+)/,
+  // export type Name or export interface Name
+  type: /^export\s+(?:type|interface)\s+(\w+)/,
+  // export default function or export default class
+  defaultExport: /^export\s+default\s+(?:function|class)\s+(\w+)/,
+};
+
+// ============================================================================
+// Parsing Functions
+// ============================================================================
+
+/**
+ * Parse comma-separated values from a tag value string
+ *
+ * Handles whitespace, quotes, and empty values.
+ *
+ * @param value - Raw tag value string
+ * @returns Array of trimmed, non-empty values
+ *
+ * @example
+ * ```typescript
+ * parseCommaSeparated('auth, user-management, security')
+ * // Returns: ['auth', 'user-management', 'security']
+ * ```
+ */
+function parseCommaSeparated(value: string): string[] {
+  return value
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+/**
+ * Extract TSDoc metadata from a single comment block
+ *
+ * Parses @context and @aliases tags, and extracts the first line
+ * as a description if it doesn't start with @.
+ *
+ * @param comment - Comment content (without delimiters)
+ * @returns Parsed TSDoc metadata
+ *
+ * @example
+ * ```typescript
+ * const metadata = extractTSDocFromComment(`
+ *   * Authenticates a user with credentials
+ *   * @context authentication, security
+ *   * @aliases login, signin
+ * `);
+ * // Returns: {
+ * //   tags: ['authentication', 'security'],
+ * //   aliases: ['login', 'signin'],
+ * //   description: 'Authenticates a user with credentials'
+ * // }
+ * ```
+ */
+function extractTSDocFromComment(comment: string): TSDocMetadata {
+  const tags: string[] = [];
+  const aliases: string[] = [];
+  let description: string | undefined;
+
+  // Extract @context tags
+  let match: RegExpExecArray | null;
+  const contextRegex = new RegExp(CONTEXT_TAG_REGEX.source, 'gi');
+  while ((match = contextRegex.exec(comment)) !== null) {
+    tags.push(...parseCommaSeparated(match[1]));
+  }
+
+  // Extract @aliases tags
+  const aliasesRegex = new RegExp(ALIASES_TAG_REGEX.source, 'gi');
+  while ((match = aliasesRegex.exec(comment)) !== null) {
+    aliases.push(...parseCommaSeparated(match[1]));
+  }
+
+  // Extract description (first non-@ line)
+  const descMatch = comment.match(DESCRIPTION_REGEX);
+  if (descMatch) {
+    description = descMatch[1].trim();
+    // Remove leading asterisks from multi-line comments
+    description = description.replace(/^\*\s*/, '');
+    // Limit to 100 chars
+    if (description.length > 100) {
+      description = description.substring(0, 97) + '...';
+    }
+  }
+
+  return { tags, aliases, description };
+}
+
+/**
+ * Extract TSDoc metadata from file content
+ *
+ * Finds the first JSDoc comment in the file (typically module-level)
+ * and extracts @context and @aliases tags from it.
+ *
+ * @param content - Full TypeScript file content
+ * @returns Aggregated TSDoc metadata from all comments
+ *
+ * @example
+ * ```typescript
+ * import { extractTSDocMetadata } from './tsdoc-parser.js';
+ *
+ * const content = `
+ * /**
+ *  * User authentication module
+ *  * @context authentication, security
+ *  * @aliases auth, login
+ *  *\/
+ * export function authenticate() {}
+ * `;
+ *
+ * const metadata = extractTSDocMetadata(content);
+ * // Returns: {
+ * //   tags: ['authentication', 'security'],
+ * //   aliases: ['auth', 'login'],
+ * //   description: 'User authentication module'
+ * // }
+ * ```
+ */
+export function extractTSDocMetadata(content: string): TSDocMetadata {
+  const allTags: string[] = [];
+  const allAliases: string[] = [];
+  let firstDescription: string | undefined;
+
+  // Find all JSDoc comments
+  const commentRegex = new RegExp(JSDOC_COMMENT_REGEX.source, 'g');
+  let match: RegExpExecArray | null;
+
+  while ((match = commentRegex.exec(content)) !== null) {
+    const metadata = extractTSDocFromComment(match[1]);
+    allTags.push(...metadata.tags);
+    allAliases.push(...metadata.aliases);
+    if (!firstDescription && metadata.description) {
+      firstDescription = metadata.description;
+    }
+  }
+
+  // Deduplicate tags and aliases
+  return {
+    tags: [...new Set(allTags)],
+    aliases: [...new Set(allAliases)],
+    description: firstDescription,
+  };
+}
+
+/**
+ * Determine if a name is likely a React component
+ *
+ * React components by convention start with an uppercase letter.
+ *
+ * @param name - Export name to check
+ * @returns True if the name follows React component naming convention
+ */
+function isLikelyComponent(name: string): boolean {
+  return /^[A-Z][a-zA-Z0-9]*$/.test(name);
+}
+
+/**
+ * Find the JSDoc comment immediately preceding a line
+ *
+ * Searches backwards from the given line to find an associated comment.
+ *
+ * @param lines - Array of file lines
+ * @param lineIndex - Index of the export line (0-indexed)
+ * @returns Comment content if found, undefined otherwise
+ */
+function findPrecedingComment(lines: string[], lineIndex: number): string | undefined {
+  // Look for a comment ending on the line before
+  let i = lineIndex - 1;
+
+  // Skip blank lines
+  while (i >= 0 && lines[i].trim() === '') {
+    i--;
+  }
+
+  if (i < 0) return undefined;
+
+  // Check if this line ends a block comment
+  const endLine = lines[i].trim();
+  if (!endLine.endsWith('*/')) return undefined;
+
+  // Find the start of the comment
+  const commentLines: string[] = [];
+  while (i >= 0) {
+    const line = lines[i];
+    commentLines.unshift(line);
+    if (line.includes('/**') || line.includes('/*')) {
+      break;
+    }
+    i--;
+  }
+
+  return commentLines.join('\n');
+}
+
+/**
+ * Extract all exports from a TypeScript file
+ *
+ * Parses the file to find all exported functions, components, classes,
+ * constants, and types. Associates each export with its TSDoc metadata.
+ *
+ * @param content - Full TypeScript file content
+ * @returns Array of export information with metadata
+ *
+ * @example
+ * ```typescript
+ * import { extractExports } from './tsdoc-parser.js';
+ *
+ * const content = `
+ * /**
+ *  * Button component
+ *  * @context ui, components
+ *  *\/
+ * export function Button() { return <button />; }
+ *
+ * /**
+ *  * Input field component
+ *  * @context ui, forms
+ *  *\/
+ * export const Input = () => <input />;
+ * `;
+ *
+ * const exports = extractExports(content);
+ * // Returns: [
+ * //   { name: 'Button', type: 'component', metadata: {...}, line: 5 },
+ * //   { name: 'Input', type: 'component', metadata: {...}, line: 11 }
+ * // ]
+ * ```
+ */
+export function extractExports(content: string): ExportInfo[] {
+  const exports: ExportInfo[] = [];
+  const lines = content.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmedLine = line.trim();
+
+    // Skip non-export lines
+    if (!trimmedLine.startsWith('export')) continue;
+
+    let name: string | undefined;
+    let type: ExportInfo['type'] = 'constant';
+
+    // Try each pattern
+    for (const [patternType, regex] of Object.entries(EXPORT_PATTERNS)) {
+      const match = trimmedLine.match(regex);
+      if (match) {
+        name = match[1];
+
+        // Determine type
+        if (patternType === 'function' || patternType === 'arrowFunction') {
+          type = isLikelyComponent(name) ? 'component' : 'function';
+        } else if (patternType === 'class') {
+          type = 'class';
+        } else if (patternType === 'type') {
+          type = 'type';
+        } else if (patternType === 'defaultExport') {
+          type = isLikelyComponent(name) ? 'component' : 'function';
+        } else {
+          // Check if it's a component based on naming
+          type = isLikelyComponent(name) ? 'component' : 'constant';
+        }
+        break;
+      }
+    }
+
+    if (!name) continue;
+
+    // Find preceding JSDoc comment
+    const commentContent = findPrecedingComment(lines, i);
+    let metadata: TSDocMetadata = { tags: [], aliases: [] };
+
+    if (commentContent) {
+      // Extract from the comment block
+      const commentMatch = commentContent.match(/\/\*\*?([\s\S]*?)\*\//);
+      if (commentMatch) {
+        metadata = extractTSDocFromComment(commentMatch[1]);
+      }
+    }
+
+    // Add the export name as an implicit tag (converted to kebab-case)
+    const implicitTag = name
+      .replace(/([a-z])([A-Z])/g, '$1-$2')
+      .toLowerCase();
+    if (!metadata.tags.includes(implicitTag)) {
+      metadata.tags.push(implicitTag);
+    }
+
+    exports.push({
+      name,
+      type,
+      metadata,
+      line: i + 1, // Convert to 1-indexed
+    });
+  }
+
+  return exports;
+}
+
+/**
+ * Parse complete metadata for a TypeScript file
+ *
+ * Combines file-level TSDoc metadata with all export metadata
+ * to create a complete picture of the file's context.
+ *
+ * @param filePath - Path to the file (for metadata)
+ * @param content - Full file content
+ * @returns Complete file metadata
+ *
+ * @example
+ * ```typescript
+ * import { parseFileMetadata } from './tsdoc-parser.js';
+ * import * as fs from 'fs/promises';
+ *
+ * const content = await fs.readFile('src/auth/login.ts', 'utf-8');
+ * const metadata = parseFileMetadata('src/auth/login.ts', content);
+ *
+ * console.log(metadata.tags);    // ['authentication', 'security', 'login-form']
+ * console.log(metadata.exports); // Array of ExportInfo
+ * ```
+ */
+export function parseFileMetadata(filePath: string, content: string): FileMetadata {
+  const now = new Date().toISOString();
+
+  // Get file-level metadata from first comment
+  const fileMetadata = extractTSDocMetadata(content);
+
+  // Get all exports with their metadata
+  const exports = extractExports(content);
+
+  // Aggregate all tags and aliases
+  const allTags = new Set<string>(fileMetadata.tags);
+  const allAliases = new Set<string>(fileMetadata.aliases);
+
+  for (const exp of exports) {
+    for (const tag of exp.metadata.tags) {
+      allTags.add(tag);
+    }
+    for (const alias of exp.metadata.aliases) {
+      allAliases.add(alias);
+    }
+  }
+
+  return {
+    path: filePath,
+    lastModified: now, // Caller should set this from file stat
+    lastIndexed: now,
+    tags: [...allTags],
+    aliases: [...allAliases],
+    exports,
+    description: fileMetadata.description,
+  };
+}


### PR DESCRIPTION
## Summary

- Install Anthropic's official feature-dev plugin
- Fix MODULE_NOT_FOUND errors in project-context hooks by copying missing utilities to plugin-local shared
- Fix incorrect import pattern in CLAUDE.md documentation
- Trim CLAUDE.md from 97 to 64 lines while preserving essential content

## Changes

### Feature-dev Plugin
- Added `feature-dev@claude-code-plugins` to enabled plugins in settings.json

### Hook Module Resolution Fix
Two hooks (`add-folder-context.ts`, `track-task-scope.ts`) used `../../../shared/` imports pointing to the repo root. When plugins are cached to `~/.claude/plugins/cache/`, the repo root doesn't exist - only plugin-local shared copies.

**Fixed by:**
- Copied 3 missing utilities to `plugins/project-context/shared/hooks/utils/`:
  - `plan-parser.ts`
  - `tsdoc-parser.ts`
  - `metadata-index.ts`
- Updated imports from `../../../shared/` → `../shared/`

### CLAUDE.md Documentation
- Fixed wrong import pattern in hook example (was documenting the broken pattern!)
- Added explicit warning about correct import path
- Trimmed verbose sections (34% reduction)

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] Reinstall project-context plugin and verify no MODULE_NOT_FOUND errors
- [ ] Verify feature-dev plugin is available

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>