### PR TITLE
feat: Smart branch naming and fix port conflict timing (#191)

### DIFF
--- a/plugins/github-context/hooks/hooks.json
+++ b/plugins/github-context/hooks/hooks.json
@@ -35,7 +35,7 @@
           {
             "type": "command",
             "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/create-issue-on-prompt.ts",
-            "description": "Creates GitHub issue on first user prompt for branch tracking"
+            "description": "Creates GitHub issue on first prompt, renames branch to {issueNum}-{type}/{name}"
           }
         ]
       }

--- a/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/port.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/port.ts
@@ -8,6 +8,10 @@
  */
 
 import { createServer } from 'net';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
 
 /**
  * Check if a TCP port is available
@@ -86,4 +90,81 @@ export async function findAvailablePort(
     }
   }
   return null;
+}
+
+/**
+ * Kill process(es) using a specific port
+ *
+ * Uses lsof to find the process ID and kills it. This is useful for freeing up
+ * ports that are held by stale dev servers from previous sessions.
+ *
+ * @param port - Port number to free up
+ * @returns Promise that resolves to true if process was killed, false otherwise
+ *
+ * @example
+ * ```typescript
+ * import { killProcessOnPort } from './port.js';
+ *
+ * const killed = await killProcessOnPort(3000);
+ * if (killed) {
+ *   console.log('Freed up port 3000');
+ * }
+ * ```
+ */
+export async function killProcessOnPort(port: number): Promise<boolean> {
+  try {
+    // Use lsof to find processes listening on the port
+    const { stdout } = await execAsync(`lsof -ti tcp:${port}`, { timeout: 5000 });
+    const pids = stdout.trim().split('\n').filter(Boolean);
+
+    if (pids.length === 0) {
+      return false;
+    }
+
+    // Kill all processes found
+    for (const pid of pids) {
+      try {
+        await execAsync(`kill -9 ${pid}`, { timeout: 5000 });
+      } catch {
+        // Process might have already exited
+      }
+    }
+
+    // Verify port is now available (give it a moment)
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    return await isPortAvailable(port);
+  } catch {
+    // lsof returned non-zero (no process found) or other error
+    return false;
+  }
+}
+
+/**
+ * Kill processes on multiple ports
+ *
+ * Kills processes on all specified ports in parallel.
+ *
+ * @param ports - Array of port numbers to free up
+ * @returns Promise that resolves to array of results with port and success status
+ *
+ * @example
+ * ```typescript
+ * import { killProcessesOnPorts } from './port.js';
+ *
+ * const results = await killProcessesOnPorts([3000, 3001, 3002]);
+ * for (const { port, killed } of results) {
+ *   console.log(`Port ${port}: ${killed ? 'freed' : 'failed or not in use'}`);
+ * }
+ * ```
+ */
+export async function killProcessesOnPorts(
+  ports: number[]
+): Promise<Array<{ port: number; killed: boolean }>> {
+  const results = await Promise.all(
+    ports.map(async (port) => ({
+      port,
+      killed: await killProcessOnPort(port),
+    }))
+  );
+  return results;
 }


### PR DESCRIPTION
## Summary

- **Issue #191**: Auto-rename branches to `{issueNum}-{type}/{name}` on first prompt
- **Bug Fix**: Port conflict resolution now runs BEFORE starting dev servers

## Changes

### Smart Branch Naming (Issue #191)
- Detects work type from prompt keywords (feature/fix/docs/refactor/chore)
- Generates kebab-case name from issue title (max 40 chars)
- Renames branch after issue creation: `claude-stellar-hedgehog` → `42-feature/add-dark-mode`
- Updates remote if branch was already pushed

### Port Conflict Fix
- Added `killProcessOnPort()` function to terminate stale processes
- Moved conflict detection BEFORE `startDevServerBackground()` call
- Prevents `EADDRINUSE` errors in Turborepo projects (nodes-md)
- Removed redundant post-start `resolvePortConflicts()` call

## Test plan

- [ ] Start new worktree, submit first prompt → verify branch renamed with issue number and type prefix
- [ ] Start nodes-md session with ports already in use → verify stale processes killed and servers start successfully

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)