### PR TITLE
feat: Multi-worktree Supabase instance isolation

### DIFF
--- a/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/process-info.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/process-info.ts
@@ -1,0 +1,226 @@
+/**
+ * Process Information Utility
+ * Identifies processes using specific ports for debugging and diagnostics.
+ * Provides graceful fallbacks when system tools are unavailable.
+ * @module process-info
+ */
+
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+/**
+ * Information about a process using a port
+ */
+export interface ProcessInfo {
+  /** Process ID (null if cannot be determined) */
+  pid: number | null;
+  /** Process name (null if cannot be determined) */
+  name: string | null;
+  /** Full command line (null if cannot be determined) */
+  command: string | null;
+}
+
+/**
+ * Extended process info with port context
+ */
+export interface PortProcessInfo extends ProcessInfo {
+  /** Port number being used */
+  port: number;
+  /** Whether a process was found on the port */
+  found: boolean;
+}
+
+/**
+ * Get information about the process using a specific port
+ * Uses lsof and ps commands (best effort, graceful fallback)
+ *
+ * @param port - Port number to check
+ * @returns Process information (fields may be null if unavailable)
+ *
+ * @example
+ * ```typescript
+ * const info = await getProcessOnPort(3000);
+ * if (info.pid) {
+ *   console.log(`Port 3000 used by ${info.name} (PID: ${info.pid})`);
+ * }
+ * ```
+ */
+export async function getProcessOnPort(port: number): Promise<ProcessInfo> {
+  const result: ProcessInfo = {
+    pid: null,
+    name: null,
+    command: null,
+  };
+
+  try {
+    // Try lsof first (works on macOS and Linux)
+    const lsofResult = await execAsync(`lsof -ti tcp:${port}`, { timeout: 5000 });
+    const pids = lsofResult.stdout.trim().split('\n').filter(Boolean);
+
+    if (pids.length === 0) {
+      return result;
+    }
+
+    // Take the first PID found
+    const pid = parseInt(pids[0], 10);
+    if (isNaN(pid)) {
+      return result;
+    }
+
+    result.pid = pid;
+
+    // Try to get process name and command
+    try {
+      const psResult = await execAsync(`ps -p ${pid} -o comm=,args=`, { timeout: 5000 });
+      const psOutput = psResult.stdout.trim();
+
+      if (psOutput) {
+        // ps output format: "comm args" - comm is first word, rest is args
+        const parts = psOutput.split(/\s+/);
+        result.name = parts[0] || null;
+        result.command = psOutput;
+      }
+    } catch {
+      // ps failed, try alternative approach
+      try {
+        // Try just getting the command name
+        const commResult = await execAsync(`ps -p ${pid} -o comm=`, { timeout: 5000 });
+        result.name = commResult.stdout.trim() || null;
+      } catch {
+        // Ignore - we at least have the PID
+      }
+    }
+  } catch {
+    // lsof failed - port might not be in use or lsof not available
+  }
+
+  return result;
+}
+
+/**
+ * Get process information for multiple ports
+ * Runs checks in parallel for efficiency
+ *
+ * @param ports - Array of port numbers to check
+ * @returns Array of port process info objects
+ *
+ * @example
+ * ```typescript
+ * const infos = await getProcessesOnPorts([3000, 54321, 54323]);
+ * for (const info of infos) {
+ *   if (info.found) {
+ *     console.log(`Port ${info.port}: ${info.name} (PID: ${info.pid})`);
+ *   }
+ * }
+ * ```
+ */
+export async function getProcessesOnPorts(ports: number[]): Promise<PortProcessInfo[]> {
+  const results = await Promise.all(
+    ports.map(async (port): Promise<PortProcessInfo> => {
+      const info = await getProcessOnPort(port);
+      return {
+        ...info,
+        port,
+        found: info.pid !== null,
+      };
+    })
+  );
+  return results;
+}
+
+/**
+ * Check if lsof command is available on the system
+ * Useful for deciding whether to attempt process identification
+ *
+ * @returns true if lsof is available
+ */
+export async function isLsofAvailable(): Promise<boolean> {
+  try {
+    await execAsync('which lsof', { timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Format process info for display
+ * Creates a human-readable string describing the process
+ *
+ * @param info - Process information object
+ * @returns Formatted string (e.g., "node (PID: 12345)")
+ */
+export function formatProcessInfo(info: ProcessInfo): string {
+  if (info.pid === null) {
+    return 'unknown process';
+  }
+
+  if (info.name) {
+    return `${info.name} (PID: ${info.pid})`;
+  }
+
+  return `PID: ${info.pid}`;
+}
+
+/**
+ * Check if a process appears to be a Supabase-related process
+ * Based on common Supabase container/process names
+ *
+ * @param info - Process information to check
+ * @returns true if process appears Supabase-related
+ */
+export function isSupabaseProcess(info: ProcessInfo): boolean {
+  if (!info.name && !info.command) {
+    return false;
+  }
+
+  const searchText = `${info.name || ''} ${info.command || ''}`.toLowerCase();
+
+  const supabaseIndicators = [
+    'supabase',
+    'postgres',
+    'postgrest',
+    'gotrue',
+    'realtime',
+    'storage',
+    'kong',
+    'inbucket',
+    'studio',
+    'pg_',
+    'docker',
+    'containerd',
+  ];
+
+  return supabaseIndicators.some((indicator) => searchText.includes(indicator));
+}
+
+/**
+ * Get a summary of processes using Supabase ports
+ * Useful for diagnostics and debugging
+ *
+ * @param ports - Port set to check (as array or individual ports)
+ * @returns Summary object with counts and details
+ */
+export async function getSupabaseProcessSummary(ports: number[]): Promise<{
+  totalPorts: number;
+  portsInUse: number;
+  supabaseProcesses: number;
+  otherProcesses: number;
+  details: PortProcessInfo[];
+}> {
+  const details = await getProcessesOnPorts(ports);
+
+  const portsInUse = details.filter((d) => d.found).length;
+  const supabaseProcesses = details.filter((d) => d.found && isSupabaseProcess(d)).length;
+  const otherProcesses = portsInUse - supabaseProcesses;
+
+  return {
+    totalPorts: ports.length,
+    portsInUse,
+    supabaseProcesses,
+    otherProcesses,
+    details,
+  };
+}

--- a/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/supabase-ports.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/supabase-ports.ts
@@ -1,0 +1,356 @@
+/**
+ * Supabase Port Management Utility
+ * Manages port allocation for multiple concurrent Supabase instances across worktrees.
+ * @module supabase-ports
+ */
+
+import { readFileSync, writeFileSync, existsSync, copyFileSync } from 'fs';
+import { join } from 'path';
+import { isPortAvailable, killProcessOnPort } from './port.js';
+
+/**
+ * Default Supabase service ports
+ */
+export const SUPABASE_DEFAULT_PORTS = {
+  api: 54321,
+  db: 54322,
+  shadowDb: 54320,
+  studio: 54323,
+  inbucket: 54324,
+  analytics: 54327,
+  pooler: 54329,
+  edgeRuntime: 8083,
+} as const;
+
+/**
+ * Port increment between slots (allows ~25 concurrent instances)
+ */
+export const PORT_INCREMENT = 10;
+
+/**
+ * A complete set of Supabase service ports
+ */
+export interface SupabasePortSet {
+  api: number;
+  db: number;
+  shadowDb: number;
+  studio: number;
+  inbucket: number;
+  analytics: number;
+  pooler: number;
+  edgeRuntime: number;
+}
+
+/**
+ * Result of checking port usage
+ */
+export interface PortUsageResult {
+  /** All critical ports (API, DB, Studio) are in use */
+  allRunning: boolean;
+  /** At least one port is in use but not all */
+  someRunning: boolean;
+  /** List of ports currently in use */
+  runningPorts: number[];
+  /** Ports that are available */
+  availablePorts: number[];
+}
+
+/**
+ * Calculate a port set for a given slot number
+ * Slot 0 = default ports, Slot 1 = +10, Slot 2 = +20, etc.
+ *
+ * @param slot - Slot number (0 for default, 1+ for worktrees)
+ * @returns Complete port set for the slot
+ */
+export function calculatePortSet(slot: number): SupabasePortSet {
+  const offset = slot * PORT_INCREMENT;
+  return {
+    api: SUPABASE_DEFAULT_PORTS.api + offset,
+    db: SUPABASE_DEFAULT_PORTS.db + offset,
+    shadowDb: SUPABASE_DEFAULT_PORTS.shadowDb + offset,
+    studio: SUPABASE_DEFAULT_PORTS.studio + offset,
+    inbucket: SUPABASE_DEFAULT_PORTS.inbucket + offset,
+    analytics: SUPABASE_DEFAULT_PORTS.analytics + offset,
+    pooler: SUPABASE_DEFAULT_PORTS.pooler + offset,
+    edgeRuntime: SUPABASE_DEFAULT_PORTS.edgeRuntime + offset,
+  };
+}
+
+/**
+ * Get all ports from a port set as an array
+ *
+ * @param ports - Port set to extract from
+ * @returns Array of all port numbers
+ */
+export function getPortArray(ports: SupabasePortSet): number[] {
+  return [
+    ports.api,
+    ports.db,
+    ports.shadowDb,
+    ports.studio,
+    ports.inbucket,
+    ports.analytics,
+    ports.pooler,
+    ports.edgeRuntime,
+  ];
+}
+
+/**
+ * Critical ports that indicate Supabase is fully running
+ * If all three are in use, Supabase is considered "fully running"
+ */
+const CRITICAL_PORTS: (keyof typeof SUPABASE_DEFAULT_PORTS)[] = ['api', 'db', 'studio'];
+
+/**
+ * Check which Supabase services are running on default ports
+ * Determines if instance is fully running, partially running, or not running
+ *
+ * @param portSet - Optional port set to check (defaults to default ports)
+ * @returns Port usage information
+ */
+export async function checkSupabasePortUsage(
+  portSet: SupabasePortSet = calculatePortSet(0)
+): Promise<PortUsageResult> {
+  const criticalPorts = CRITICAL_PORTS.map((key) => portSet[key]);
+  const allPorts = getPortArray(portSet);
+
+  const runningPorts: number[] = [];
+  const availablePorts: number[] = [];
+
+  // Check all ports in parallel
+  const results = await Promise.all(
+    allPorts.map(async (port) => ({
+      port,
+      available: await isPortAvailable(port),
+    }))
+  );
+
+  for (const { port, available } of results) {
+    if (available) {
+      availablePorts.push(port);
+    } else {
+      runningPorts.push(port);
+    }
+  }
+
+  // Check if all critical ports are in use
+  const criticalInUse = criticalPorts.filter((p) => runningPorts.includes(p));
+  const allRunning = criticalInUse.length === CRITICAL_PORTS.length;
+  const someRunning = runningPorts.length > 0 && !allRunning;
+
+  return {
+    allRunning,
+    someRunning,
+    runningPorts,
+    availablePorts,
+  };
+}
+
+/**
+ * Find the next available port slot
+ * Starts from slot 1 and increments until finding a slot with all ports available
+ *
+ * @param maxSlots - Maximum number of slots to check (default: 25)
+ * @returns Slot number with available ports, or null if none found
+ */
+export async function findAvailableSlot(maxSlots: number = 25): Promise<number | null> {
+  for (let slot = 1; slot <= maxSlots; slot++) {
+    const portSet = calculatePortSet(slot);
+    const usage = await checkSupabasePortUsage(portSet);
+
+    // If no critical ports are in use, this slot is available
+    if (usage.runningPorts.length === 0) {
+      return slot;
+    }
+  }
+  return null;
+}
+
+/**
+ * Find an available port set, starting from a given slot
+ *
+ * @param startSlot - Slot to start checking from (default: 1)
+ * @returns Port set with all available ports, or null if none found
+ */
+export async function findAvailablePortSet(startSlot: number = 1): Promise<{
+  slot: number;
+  ports: SupabasePortSet;
+} | null> {
+  const slot = await findAvailableSlot(25);
+  if (slot === null || slot < startSlot) {
+    return null;
+  }
+  return {
+    slot,
+    ports: calculatePortSet(slot),
+  };
+}
+
+/**
+ * Kill stale Supabase processes on a port set
+ * Useful for cleaning up partial/crashed instances
+ *
+ * @param portSet - Ports to clean up
+ * @returns Results of kill attempts for each port
+ */
+export async function killStaleSupabasePorts(
+  portSet: SupabasePortSet = calculatePortSet(0)
+): Promise<Array<{ port: number; killed: boolean }>> {
+  const ports = getPortArray(portSet);
+  const results = await Promise.all(
+    ports.map(async (port) => {
+      const available = await isPortAvailable(port);
+      if (available) {
+        return { port, killed: false };
+      }
+      const killed = await killProcessOnPort(port);
+      return { port, killed };
+    })
+  );
+  return results;
+}
+
+// ==================== Config.toml Management ====================
+
+/**
+ * Parse port values from a Supabase config.toml file
+ * Uses regex to extract port settings from TOML content
+ *
+ * @param configPath - Path to config.toml
+ * @returns Current port configuration, or null if can't be parsed
+ */
+export function parseSupabaseConfigPorts(configPath: string): SupabasePortSet | null {
+  if (!existsSync(configPath)) {
+    return null;
+  }
+
+  try {
+    const content = readFileSync(configPath, 'utf-8');
+
+    // Extract ports using regex patterns
+    // Format: port = 54321 (with optional whitespace)
+    const extractPort = (section: string, key: string = 'port'): number | null => {
+      // Build regex to match [section] followed by key = value
+      const sectionRegex = new RegExp(`\\[${section}\\]([\\s\\S]*?)(?=\\n\\[|$)`, 'm');
+      const sectionMatch = content.match(sectionRegex);
+      if (!sectionMatch) return null;
+
+      const sectionContent = sectionMatch[1];
+      const portRegex = new RegExp(`^\\s*${key}\\s*=\\s*(\\d+)`, 'm');
+      const portMatch = sectionContent.match(portRegex);
+      return portMatch ? parseInt(portMatch[1], 10) : null;
+    };
+
+    return {
+      api: extractPort('api') ?? SUPABASE_DEFAULT_PORTS.api,
+      db: extractPort('db') ?? SUPABASE_DEFAULT_PORTS.db,
+      shadowDb: extractPort('db', 'shadow_port') ?? SUPABASE_DEFAULT_PORTS.shadowDb,
+      studio: extractPort('studio') ?? SUPABASE_DEFAULT_PORTS.studio,
+      inbucket: extractPort('inbucket') ?? SUPABASE_DEFAULT_PORTS.inbucket,
+      analytics: extractPort('analytics') ?? SUPABASE_DEFAULT_PORTS.analytics,
+      pooler: extractPort('db\\.pooler') ?? extractPort('db', 'pooler_port') ?? SUPABASE_DEFAULT_PORTS.pooler,
+      edgeRuntime: extractPort('edge_runtime', 'inspector_port') ?? SUPABASE_DEFAULT_PORTS.edgeRuntime,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Update port values in a Supabase config.toml file
+ * Creates a backup before modifying
+ *
+ * @param configPath - Path to config.toml
+ * @param ports - New port values to set
+ * @param backupSuffix - Suffix for backup file (default: '.backup')
+ * @returns Path to backup file
+ */
+export function updateSupabaseConfigPorts(
+  configPath: string,
+  ports: SupabasePortSet,
+  backupSuffix: string = '.backup'
+): string {
+  if (!existsSync(configPath)) {
+    throw new Error(`Config file not found: ${configPath}`);
+  }
+
+  // Create backup
+  const backupPath = `${configPath}${backupSuffix}`;
+  copyFileSync(configPath, backupPath);
+
+  let content = readFileSync(configPath, 'utf-8');
+
+  // Helper to update a port in a section
+  const updatePort = (section: string, key: string, value: number): void => {
+    // Pattern to match the section and the key within it
+    const sectionRegex = new RegExp(`(\\[${section}\\][\\s\\S]*?)(${key}\\s*=\\s*)(\\d+)`, 'gm');
+
+    // Check if the key exists in the section
+    if (sectionRegex.test(content)) {
+      // Reset regex state
+      sectionRegex.lastIndex = 0;
+      content = content.replace(sectionRegex, `$1$2${value}`);
+    } else {
+      // Key doesn't exist, try to add it after section header
+      const addKeyRegex = new RegExp(`(\\[${section}\\]\\s*\\n)`, 'm');
+      if (addKeyRegex.test(content)) {
+        content = content.replace(addKeyRegex, `$1${key} = ${value}\n`);
+      }
+    }
+  };
+
+  // Update each port
+  updatePort('api', 'port', ports.api);
+  updatePort('db', 'port', ports.db);
+  updatePort('db', 'shadow_port', ports.shadowDb);
+  updatePort('db\\.pooler', 'port', ports.pooler);
+  updatePort('studio', 'port', ports.studio);
+  updatePort('inbucket', 'port', ports.inbucket);
+  updatePort('analytics', 'port', ports.analytics);
+  updatePort('edge_runtime', 'inspector_port', ports.edgeRuntime);
+
+  writeFileSync(configPath, content, 'utf-8');
+
+  return backupPath;
+}
+
+/**
+ * Restore config.toml from backup
+ *
+ * @param configPath - Path to config.toml
+ * @param backupSuffix - Suffix used for backup (default: '.backup')
+ * @returns true if restored, false if backup not found
+ */
+export function restoreSupabaseConfig(
+  configPath: string,
+  backupSuffix: string = '.backup'
+): boolean {
+  const backupPath = `${configPath}${backupSuffix}`;
+
+  if (!existsSync(backupPath)) {
+    return false;
+  }
+
+  copyFileSync(backupPath, configPath);
+  return true;
+}
+
+/**
+ * Get the path to supabase config.toml in a project
+ *
+ * @param cwd - Project root directory
+ * @returns Path to config.toml
+ */
+export function getSupabaseConfigPath(cwd: string): string {
+  return join(cwd, 'supabase', 'config.toml');
+}
+
+/**
+ * Check if a project has Supabase initialized
+ *
+ * @param cwd - Project root directory
+ * @returns true if supabase/config.toml exists
+ */
+export function hasSupabaseConfig(cwd: string): boolean {
+  return existsSync(getSupabaseConfigPath(cwd));
+}

--- a/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/worktree.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/worktree.ts
@@ -1,0 +1,215 @@
+/**
+ * Git Worktree Detection Utility
+ * Detects if the current directory is a git worktree and provides worktree information
+ * for consistent port allocation across concurrent sessions.
+ * @module worktree
+ */
+
+import { existsSync, readFileSync, statSync } from 'fs';
+import { join, dirname, resolve } from 'path';
+import { createHash } from 'crypto';
+
+/**
+ * Information about a git worktree
+ */
+export interface WorktreeInfo {
+  /** Whether the current directory is a git worktree (not main repo) */
+  isWorktree: boolean;
+  /** Full path to the worktree root directory */
+  worktreePath: string;
+  /** Path to the main repository (same as worktreePath if not a worktree) */
+  parentRepoPath: string;
+  /** Short hash (8 chars) for unique identification, used for port slot allocation */
+  worktreeId: string;
+  /** Worktree name extracted from path (e.g., "claude-brave-zebra-k8fifpgr") */
+  worktreeName: string;
+}
+
+/**
+ * Generate a stable worktree ID from a path
+ * Uses SHA256 hash truncated to 8 characters for uniqueness while being short
+ *
+ * @param path - The path to hash
+ * @returns 8-character hex string
+ */
+export function getWorktreeId(path: string): string {
+  const hash = createHash('sha256').update(path).digest('hex');
+  return hash.substring(0, 8);
+}
+
+/**
+ * Calculate a numeric slot from worktree ID for port allocation
+ * Converts the hex worktree ID to a slot number (1-99)
+ *
+ * @param worktreeId - 8-character hex worktree ID
+ * @returns Slot number (1-99), or 0 for main repo
+ */
+export function getWorktreeSlot(worktreeId: string): number {
+  // Convert first 4 hex chars to number, mod 99, + 1 to get 1-99 range
+  const num = parseInt(worktreeId.substring(0, 4), 16);
+  return (num % 99) + 1;
+}
+
+/**
+ * Find the git root directory from a given path
+ * Walks up the directory tree looking for .git
+ *
+ * @param startPath - Starting directory
+ * @returns Path to git root, or null if not in a git repo
+ */
+function findGitRoot(startPath: string): string | null {
+  let current = resolve(startPath);
+  const root = '/';
+
+  while (current !== root) {
+    const gitPath = join(current, '.git');
+    if (existsSync(gitPath)) {
+      return current;
+    }
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+
+  return null;
+}
+
+/**
+ * Parse the .git file in a worktree to extract the gitdir path
+ * Worktrees have a .git FILE (not directory) containing: gitdir: /path/to/main/.git/worktrees/name
+ *
+ * @param gitFilePath - Path to the .git file
+ * @returns The gitdir path, or null if invalid
+ */
+function parseGitFile(gitFilePath: string): string | null {
+  try {
+    const content = readFileSync(gitFilePath, 'utf-8').trim();
+    const match = content.match(/^gitdir:\s*(.+)$/);
+    if (match) {
+      return match[1].trim();
+    }
+  } catch {
+    // File doesn't exist or can't be read
+  }
+  return null;
+}
+
+/**
+ * Extract the main repository path from a worktree gitdir path
+ * gitdir format: /path/to/main-repo/.git/worktrees/worktree-name
+ *
+ * @param gitdir - The gitdir path from .git file
+ * @returns Path to the main repository
+ */
+function extractParentRepoPath(gitdir: string): string {
+  // gitdir looks like: /path/to/repo/.git/worktrees/worktree-name
+  // We need to get: /path/to/repo
+  const worktreesIndex = gitdir.indexOf('/.git/worktrees/');
+  if (worktreesIndex !== -1) {
+    return gitdir.substring(0, worktreesIndex);
+  }
+  // Fallback: strip last two components (.git/worktrees/name -> repo path)
+  return dirname(dirname(dirname(gitdir)));
+}
+
+/**
+ * Extract worktree name from the gitdir path
+ *
+ * @param gitdir - The gitdir path from .git file
+ * @returns Worktree name (last component of path)
+ */
+function extractWorktreeName(gitdir: string): string {
+  // gitdir looks like: /path/to/repo/.git/worktrees/worktree-name
+  const parts = gitdir.split('/');
+  return parts[parts.length - 1] || 'unknown';
+}
+
+/**
+ * Detect if the current directory is a git worktree
+ * Returns comprehensive information about the worktree for port allocation
+ *
+ * @param cwd - Current working directory to check
+ * @returns WorktreeInfo object with detection results
+ *
+ * @example
+ * ```typescript
+ * const info = detectWorktree('/home/user/project-worktree');
+ * if (info.isWorktree) {
+ *   console.log(`Worktree: ${info.worktreeName}`);
+ *   console.log(`Slot: ${getWorktreeSlot(info.worktreeId)}`);
+ * }
+ * ```
+ */
+export function detectWorktree(cwd: string): WorktreeInfo {
+  const gitRoot = findGitRoot(cwd);
+
+  if (!gitRoot) {
+    // Not in a git repo at all
+    return {
+      isWorktree: false,
+      worktreePath: cwd,
+      parentRepoPath: cwd,
+      worktreeId: getWorktreeId(cwd),
+      worktreeName: 'main',
+    };
+  }
+
+  const gitPath = join(gitRoot, '.git');
+
+  // Check if .git is a file (worktree) or directory (main repo)
+  try {
+    const stats = statSync(gitPath);
+
+    if (stats.isFile()) {
+      // This is a worktree - .git is a file pointing to the main repo
+      const gitdir = parseGitFile(gitPath);
+
+      if (gitdir && gitdir.includes('/.git/worktrees/')) {
+        const parentRepoPath = extractParentRepoPath(gitdir);
+        const worktreeName = extractWorktreeName(gitdir);
+
+        return {
+          isWorktree: true,
+          worktreePath: gitRoot,
+          parentRepoPath,
+          worktreeId: getWorktreeId(gitRoot),
+          worktreeName,
+        };
+      }
+    }
+
+    // .git is a directory - this is the main repo
+    return {
+      isWorktree: false,
+      worktreePath: gitRoot,
+      parentRepoPath: gitRoot,
+      worktreeId: getWorktreeId(gitRoot),
+      worktreeName: 'main',
+    };
+  } catch {
+    // Can't stat .git - return default
+    return {
+      isWorktree: false,
+      worktreePath: cwd,
+      parentRepoPath: cwd,
+      worktreeId: getWorktreeId(cwd),
+      worktreeName: 'main',
+    };
+  }
+}
+
+/**
+ * Check if a path looks like a worktree path
+ * Quick heuristic check without full detection
+ *
+ * @param path - Path to check
+ * @returns true if path appears to be a worktree
+ */
+export function looksLikeWorktree(path: string): boolean {
+  // Common worktree path patterns
+  return (
+    path.includes('-worktrees/') ||
+    path.includes('/worktrees/') ||
+    /claude-[a-z]+-[a-z]+-[a-z0-9]+$/.test(path)
+  );
+}


### PR DESCRIPTION
## Summary

- Add support for concurrent Claude Code sessions on separate git worktrees with isolated Supabase environments
- Each worktree can have its own Supabase Docker containers/databases on non-conflicting ports
- Dev servers (Next.js, Vite, Cloudflare) also get isolated ports per worktree

## Changes

### New Files
- `shared/hooks/utils/worktree.ts` - Git worktree detection utility
- `shared/hooks/utils/supabase-ports.ts` - Supabase port management and config.toml modification
- `shared/hooks/utils/process-info.ts` - Process identification for port usage diagnostics
- Extended `shared/hooks/utils/session-state.ts` - Worktree session tracking

### Modified Files
- `hooks/install-start-supabase-next.ts` - Multi-instance logic with worktree awareness

## Port Allocation Strategy

| Service | Default | Slot 1 | Slot 2 |
|---------|---------|--------|--------|
| Supabase API | 54321 | 54331 | 54341 |
| Supabase DB | 54322 | 54332 | 54342 |
| Supabase Studio | 54323 | 54333 | 54343 |
| Next.js | 3000 | 3010 | 3020 |
| Vite | 5173 | 5183 | 5193 |
| Cloudflare | 8787 | 8797 | 8807 |

Supports up to 25 concurrent worktree instances.

## Test plan

- [ ] Test in main repo (uses default ports)
- [ ] Test in worktree when main repo Supabase is running (should allocate new slot)
- [ ] Verify env vars export correct ports
- [ ] Verify dev servers start on correct ports
- [ ] Test session resume (should reuse existing worktree session)

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)