### PR TITLE
feat: Add Supabase database isolation for concurrent sessions

### DIFF
--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/hooks.json
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/hooks.json
@@ -62,6 +62,17 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/stop-supabase-session.ts",
+            "description": "Cleans up Supabase containers for worktree sessions: stops containers, restores config.toml, updates session state"
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/stop-supabase-session.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/stop-supabase-session.ts
@@ -1,0 +1,121 @@
+/**
+ * Supabase Session Cleanup Hook
+ * Stop hook that:
+ * 1. Stops Supabase containers for worktree sessions
+ * 2. Restores config.toml from backup
+ * 3. Updates session state to mark as stopped
+ * @module stop-supabase-session
+ */
+
+import type { StopInput, StopHookOutput } from '../shared/types/types.js';
+import { runHook } from '../shared/hooks/utils/io.js';
+import { createDebugLogger } from '../shared/hooks/utils/debug.js';
+import { detectWorktree } from '../shared/hooks/utils/worktree.js';
+import {
+  loadWorktreeSupabaseSession,
+  updateWorktreeSupabaseSession,
+} from '../shared/hooks/utils/session-state.js';
+import {
+  restoreSupabaseConfig,
+  getSupabaseConfigPath,
+} from '../shared/hooks/utils/supabase-ports.js';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { existsSync } from 'fs';
+
+const execAsync = promisify(exec);
+
+interface ExecResult {
+  success: boolean;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Execute a command and return result
+ */
+async function execCommand(command: string, options: { cwd: string }): Promise<ExecResult> {
+  try {
+    const { stdout, stderr } = await execAsync(command, {
+      cwd: options.cwd,
+      timeout: 30000, // 30 seconds
+    });
+    return { success: true, stdout, stderr };
+  } catch (error: unknown) {
+    const err = error as { stdout?: string; stderr?: string; message?: string };
+    return {
+      success: false,
+      stdout: err.stdout || '',
+      stderr: err.stderr || err.message || 'Unknown error',
+    };
+  }
+}
+
+/**
+ * Stop hook handler
+ */
+async function handler(input: StopInput): Promise<StopHookOutput> {
+  const logger = createDebugLogger(input.cwd, 'stop-supabase-session', true);
+  await logger.logInput(input);
+
+  const worktreeInfo = detectWorktree(input.cwd);
+
+  // Only auto-cleanup worktrees (not main repo)
+  if (!worktreeInfo.isWorktree) {
+    const output: StopHookOutput = {
+      decision: 'approve',
+      systemMessage: 'Main repo - skipping automatic Supabase cleanup',
+    };
+    await logger.logOutput(output);
+    return output;
+  }
+
+  // Load session state
+  const session = await loadWorktreeSupabaseSession(input.cwd, worktreeInfo.worktreeId);
+  if (!session || !session.running) {
+    const output: StopHookOutput = {
+      decision: 'approve',
+      systemMessage: 'No running Supabase session found',
+    };
+    await logger.logOutput(output);
+    return output;
+  }
+
+  const messages: string[] = [];
+  messages.push(`🧹 Cleaning up Supabase for worktree: ${worktreeInfo.worktreeName}`);
+  messages.push(`   Project ID: ${session.worktreeProjectId}`);
+
+  // Stop Supabase containers
+  const stopResult = await execCommand(`supabase stop`, { cwd: input.cwd });
+  if (stopResult.success) {
+    messages.push(`✓ Stopped Supabase containers (${session.worktreeProjectId})`);
+  } else {
+    messages.push(`⚠️ Failed to stop Supabase: ${stopResult.stderr}`);
+  }
+
+  // Restore config.toml from backup
+  if (session.configBackupPath && existsSync(session.configBackupPath)) {
+    const configPath = getSupabaseConfigPath(input.cwd);
+    const restored = restoreSupabaseConfig(configPath, `.backup-${worktreeInfo.worktreeId}`);
+    if (restored) {
+      messages.push('✓ Restored config.toml from backup');
+    } else {
+      messages.push('⚠️ Failed to restore config.toml');
+    }
+  }
+
+  // Mark session as stopped
+  await updateWorktreeSupabaseSession(input.cwd, worktreeInfo.worktreeId, { running: false });
+  messages.push('✓ Session state updated');
+
+  const output: StopHookOutput = {
+    decision: 'approve',
+    systemMessage: messages.join('\n'),
+  };
+
+  await logger.logOutput(output);
+  return output;
+}
+
+export { handler };
+runHook(handler);

--- a/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/session-state.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/session-state.ts
@@ -336,6 +336,10 @@ export interface WorktreeSupabaseSession {
   configBackupPath: string;
   /** Whether instance is currently running */
   running: boolean;
+  /** Original project_id from config.toml (before modification) */
+  originalProjectId: string;
+  /** Worktree-specific project_id (original or original-{slot}) */
+  worktreeProjectId: string;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Implements full database isolation across concurrent Claude Code sessions by leveraging Supabase CLI's `project_id` mechanism. Each worktree session gets isolated Docker containers, volumes, and databases.

### Key Features

- **Container Isolation**: Each worktree gets unique project_id (`myapp`, `myapp-1`, `myapp-2`)
- **Independent Migrations**: Migrations run independently per session with isolated volumes
- **Resource Optimization**: Automatically skips disabled Supabase services (~450MB savings)
- **Automatic Cleanup**: Stop hook restores config.toml and marks sessions as stopped

### Implementation

1. **Extended `supabase-ports.ts`**: Added project_id management and service detection
2. **Updated `session-state.ts`**: Tracks originalProjectId and worktreeProjectId
3. **Modified `install-start-supabase-next.ts`**: Implements container isolation logic
4. **Created `stop-supabase-session.ts`**: New Stop hook for cleanup
5. **Registered Stop hook**: Added to hooks.json

### How It Works

**Container Naming:**
- Main repo: `supabase_db_myapp` (port 54321)
- Worktree 1: `supabase_db_myapp-1` (port 54331)
- Worktree 2: `supabase_db_myapp-2` (port 54341)

**Resource Optimization:**
- Detects enabled services in config.toml
- Builds `--exclude` flags for disabled services
- Example: `supabase start --exclude edge-runtime,logflare`

### Test Plan

- [ ] Main repo starts with original project_id
- [ ] Worktree sessions get unique project_ids
- [ ] Docker containers are isolated (`docker ps | grep supabase`)
- [ ] Migrations run independently
- [ ] Config.toml restored on session end

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)