### PR TITLE
fix(github-orchestration): Remove invalid skills/agents fields from plugin.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,7 +22,7 @@
     {
       "name": "github-orchestration",
       "description": "GitHub workflow orchestration with branch context, commit enhancement, and CI management",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "author": {
         "name": "constellos"
       },

--- a/plugins/github-orchestration/.claude-plugin/plugin.json
+++ b/plugins/github-orchestration/.claude-plugin/plugin.json
@@ -8,16 +8,5 @@
   "repository": "https://github.com/constellos/claude-code-plugins",
   "license": "MIT",
   "keywords": ["github", "orchestration", "workflow", "issues", "pr", "ci", "automation"],
-  "hooks": "./hooks/hooks.json",
-  "skills": {
-    "issue-management": "./skills/issue-management/SKILL.md",
-    "branch-orchestration": "./skills/branch-orchestration/SKILL.md",
-    "subissue-orchestration": "./skills/subissue-orchestration/SKILL.md",
-    "stacked-pr-management": "./skills/stacked-pr-management/SKILL.md",
-    "ci-orchestration": "./skills/ci-orchestration/SKILL.md",
-    "pr-workflow": "./skills/pr-workflow/SKILL.md"
-  },
-  "agents": {
-    "github-orchestrator": "./agents/github-orchestrator.md"
-  }
+  "hooks": "./hooks/hooks.json"
 }


### PR DESCRIPTION
## Summary
- Fix plugin installation failure caused by invalid `skills` and `agents` fields in plugin.json
- Update marketplace.json version to 0.2.0

## Root Cause
The `claude plugin install` command failed with:
```
Validation errors: agents: Invalid input, skills: Invalid input
```

Claude Code uses **auto-discovery** for skills and agents from directory structure, not explicit declaration in plugin.json. The object format `{name: path}` is not supported.

## Changes
- Remove `skills` object field from plugin.json
- Remove `agents` object field from plugin.json  
- Update marketplace.json version to 0.2.0

The `skills/` and `agents/` directories remain intact and will be auto-discovered.

## Test plan
- [x] Verified `claude plugin install --scope project github-orchestration@constellos-local` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)