### PR TITLE
fix(nextjs-supabase-ai-sdk-dev): Fix silent hook failures and add container cleanup

### DIFF
--- a/plugins/nextjs-supabase-ai-sdk-dev/CLAUDE.md
+++ b/plugins/nextjs-supabase-ai-sdk-dev/CLAUDE.md
@@ -23,6 +23,8 @@ Local dev environment setup for Vercel/Supabase and systematic UI development wi
 | install-start-supabase-next | SessionStart | No | Sets up Supabase local dev, installs dependencies (skips if fresh), starts dev servers (Next.js, Cloudflare, Elysia, Turborepo) with health checks |
 | cache-supabase-schema | SessionStart | No | Caches Supabase table/column metadata for context matching |
 | move-playwright-screenshots | PostToolUse[browser_eval] | No | Moves screenshots to .claude/screenshots/ to prevent permission prompts |
+| stop-supabase-session | Stop | Yes | Cleans up Supabase containers for worktree sessions |
+| cleanup-supabase-session | SessionEnd | No | Stops Supabase containers when session ends |
 
 ## Agents
 

--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/cleanup-supabase-session.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/cleanup-supabase-session.ts
@@ -1,0 +1,107 @@
+/**
+ * Supabase Session Cleanup Hook (SessionEnd)
+ * SessionEnd hook that:
+ * 1. Stops Supabase containers for the current session
+ * 2. Marks session state as stopped
+ *
+ * Unlike the Stop hook, SessionEnd cannot block session termination.
+ * This runs when the user exits the session (Ctrl+C, /clear, logout, etc.)
+ *
+ * @module cleanup-supabase-session
+ */
+
+import type { SessionEndInput, SessionEndHookOutput } from '../shared/types/types.js';
+import { runHook } from '../shared/hooks/utils/io.js';
+import { createDebugLogger } from '../shared/hooks/utils/debug.js';
+import { detectWorktree } from '../shared/hooks/utils/worktree.js';
+import {
+  loadWorktreeSupabaseSession,
+  updateWorktreeSupabaseSession,
+} from '../shared/hooks/utils/session-state.js';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+/**
+ * Execute a command and return result
+ */
+async function execCommand(
+  command: string,
+  options: { cwd: string; timeout?: number }
+): Promise<{ success: boolean; stdout: string; stderr: string }> {
+  try {
+    const { stdout, stderr } = await execAsync(command, {
+      cwd: options.cwd,
+      timeout: options.timeout ?? 30000,
+    });
+    return { success: true, stdout, stderr };
+  } catch (error: unknown) {
+    const err = error as { stdout?: string; stderr?: string; message?: string };
+    return {
+      success: false,
+      stdout: err.stdout || '',
+      stderr: err.stderr || err.message || 'Unknown error',
+    };
+  }
+}
+
+/**
+ * SessionEnd hook handler - cleanup Supabase containers on session end
+ */
+async function handler(input: SessionEndInput): Promise<SessionEndHookOutput> {
+  const logger = createDebugLogger(input.cwd, 'cleanup-supabase-session', true);
+  await logger.logInput({
+    session_id: input.session_id,
+    reason: input.reason,
+  });
+
+  const worktreeInfo = detectWorktree(input.cwd);
+
+  // Load session state
+  const session = await loadWorktreeSupabaseSession(input.cwd, worktreeInfo.worktreeId);
+
+  // Only cleanup if:
+  // 1. Session exists and is running
+  // 2. Session was started by this Claude session (matching sessionId)
+  if (!session?.running) {
+    await logger.logOutput({ success: true, reason: 'no_running_session' });
+    return {};
+  }
+
+  if (session.sessionId && session.sessionId !== input.session_id) {
+    await logger.logOutput({
+      success: true,
+      reason: 'different_session',
+      current: input.session_id,
+      session_owner: session.sessionId,
+    });
+    return {};
+  }
+
+  // Stop Supabase containers using docker directly
+  // This is faster and more reliable than `supabase stop` during exit
+  if (session.worktreeProjectId) {
+    await execCommand(
+      `docker ps -q --filter "name=supabase_.*_${session.worktreeProjectId}" | xargs -r docker stop`,
+      { cwd: input.cwd, timeout: 30000 }
+    );
+  }
+
+  // Mark session as stopped
+  await updateWorktreeSupabaseSession(input.cwd, worktreeInfo.worktreeId, {
+    running: false,
+  });
+
+  await logger.logOutput({
+    success: true,
+    cleaned: session.worktreeProjectId,
+    reason: input.reason,
+  });
+
+  // SessionEnd hooks return empty object (cannot block session termination)
+  return {};
+}
+
+export { handler };
+runHook(handler);

--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/hooks.json
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/hooks.json
@@ -73,6 +73,17 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/cleanup-supabase-session.ts",
+            "description": "Stops Supabase containers and marks session as stopped when session ends"
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/session-state.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/session-state.ts
@@ -340,6 +340,8 @@ export interface WorktreeSupabaseSession {
   originalProjectId: string;
   /** Worktree-specific project_id (original or original-{slot}) */
   worktreeProjectId: string;
+  /** Claude session ID that owns this instance (for orphan detection) */
+  sessionId?: string;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Fix `install-start-supabase-next` hook failing silently without logging output
- Add SessionEnd cleanup hook to stop containers when sessions end
- Add session ID tracking to properly identify and clean up orphaned containers

## Changes

### Silent Failure Fix
Added `logOutput()` calls to all early return paths in `install-start-supabase-next.ts`:
- CLI not installed path
- Supabase not initialized path  
- Exception catch block

### Session ID Tracking
- Added `sessionId` field to `WorktreeSupabaseSession` interface
- `startWorktreeSupabase()` now saves the Claude session ID
- `cleanupOrphanedSessions()` now cleans sessions from different Claude sessions

### SessionEnd Cleanup Hook
New hook `cleanup-supabase-session.ts` that:
- Stops Supabase containers when session ends (Ctrl+C, /clear, logout)
- Only cleans containers owned by the current session
- Marks session state as stopped

## Test plan

- [ ] Start session in project without Supabase CLI - verify output logged with `reason: 'cli_not_installed'`
- [ ] Start session in project without `supabase/config.toml` - verify output logged with `reason: 'not_initialized'`
- [ ] Start session A with Supabase, then session B - verify A's containers cleaned before B starts
- [ ] Exit session with Supabase running - verify containers stopped via `docker ps`

Closes #236
Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)