### PR TITLE
fix(nextjs-supabase-ai-sdk-dev): Add hook timeouts to prevent silent failures

### DIFF
--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/hooks.json
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/hooks.json
@@ -24,7 +24,8 @@
           {
             "type": "command",
             "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/install-start-supabase-next.ts",
-            "description": "Sets up Supabase local dev: installs CLI, starts Docker, starts Supabase, exports env vars, starts dev server"
+            "description": "Sets up Supabase local dev: installs CLI, starts Docker, starts Supabase, exports env vars, starts dev server",
+            "timeout": 600
           },
           {
             "type": "command",
@@ -69,7 +70,8 @@
           {
             "type": "command",
             "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/stop-supabase-session.ts",
-            "description": "Cleans up Supabase containers for worktree sessions: stops containers, restores config.toml, updates session state"
+            "description": "Cleans up Supabase containers for worktree sessions: stops containers, restores config.toml, updates session state",
+            "timeout": 120
           }
         ]
       }
@@ -80,7 +82,8 @@
           {
             "type": "command",
             "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/cleanup-supabase-session.ts",
-            "description": "Stops Supabase containers and marks session as stopped when session ends"
+            "description": "Stops Supabase containers and marks session as stopped when session ends",
+            "timeout": 60
           }
         ]
       }


### PR DESCRIPTION
## Summary

The default hook timeout of 60 seconds was causing `install-start-supabase-next` to be killed before completion, especially on first run when Supabase downloads Docker containers.

## Root Cause

When the hook times out:
- Input is logged to `hook-events.json`
- No output is ever logged (hook killed mid-execution)
- No session state file is created
- Containers accumulate without cleanup

## Changes

Added explicit timeouts in `hooks.json`:

| Hook | Timeout | Reason |
|------|---------|--------|
| `install-start-supabase-next` | 600s (10 min) | First run downloads Docker containers |
| `stop-supabase-session` | 120s (2 min) | Container cleanup |
| `cleanup-supabase-session` | 60s (1 min) | Session end cleanup |

## Test plan

- [ ] Start session in project with Supabase - verify hook completes and logs output
- [ ] Verify session state file is created in `.claude/logs/`
- [ ] Exit session - verify containers are cleaned up

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)