### PR TITLE
fix(nextjs-supabase-ai-sdk-dev): Complete container cleanup and smart port allocation

### DIFF
--- a/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/port.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/port.ts
@@ -168,3 +168,39 @@ export async function killProcessesOnPorts(
   );
   return results;
 }
+
+/**
+ * Find next available port scanning at +10 increments
+ *
+ * Checks ports at 10-port intervals starting from basePort until an available
+ * port is found. This allows multiple dev servers to run on predictable ports
+ * (e.g., 3000, 3010, 3020...) without conflicts.
+ *
+ * @param basePort - Starting port (e.g., 3000)
+ * @param maxSlots - Maximum slots to check (default: 25)
+ * @returns Available port, or null if none found in range
+ *
+ * @example
+ * ```typescript
+ * import { findAvailablePortAt10Increments } from './port.js';
+ *
+ * // Find next available port starting from 3000, checking 3000, 3010, 3020...
+ * const port = await findAvailablePortAt10Increments(3000);
+ * if (port) {
+ *   console.log(`Starting server on port ${port}`);
+ * }
+ * ```
+ */
+export async function findAvailablePortAt10Increments(
+  basePort: number,
+  maxSlots: number = 25
+): Promise<number | null> {
+  for (let slot = 0; slot < maxSlots; slot++) {
+    const port = basePort + slot * 10;
+    const available = await isPortAvailable(port);
+    if (available) {
+      return port;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

Fixes #249: Improves Supabase container cleanup and dev server port allocation.

- **Container deletion**: SessionEnd now runs `docker rm` after `docker stop` to fully remove containers
- **Dev server cleanup**: Kills dev server processes by port on session end
- **Smart port allocation**: Scans at +10 increments (3000, 3010, 3020...) to find available ports instead of slot-based offsets
- **Port tracking**: Saves actual allocated ports to session state for reliable cleanup

## Test plan

- [ ] Start a session with Supabase, verify ports are allocated by scanning availability
- [ ] End session, verify `docker ps -a --filter "name=supabase"` shows no containers
- [ ] Verify `lsof -ti tcp:3000` returns nothing after SessionEnd
- [ ] Start session with port 3000 in use, verify app starts on 3010
- [ ] TypeScript compiles: `bun run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)