### PR TITLE
fix(nextjs-supabase-ai-sdk-dev): Detect Supabase usage in monorepo apps with shared packages

### DIFF
--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/install-start-supabase-next.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/install-start-supabase-next.ts
@@ -16,7 +16,7 @@ import { runHook } from '../shared/hooks/utils/io.js';
 import { detectPackageManager } from '../shared/hooks/utils/package-manager.js';
 import { isPortAvailable, findAvailablePort, killProcessOnPort, findAvailablePortAt10Increments } from '../shared/hooks/utils/port.js';
 import { getWranglerDevPort } from '../shared/hooks/utils/toml.js';
-import { distributeEnvVars, mergeWorkspaceEnvVars, validateEnvVars, detectSupabaseUsage } from '../shared/hooks/utils/env-sync.js';
+import { distributeEnvVars, mergeWorkspaceEnvVars, validateEnvVars, detectSupabaseUsage, hasSupabaseInMonorepo } from '../shared/hooks/utils/env-sync.js';
 import { detectWorktree, type WorktreeInfo } from '../shared/hooks/utils/worktree.js';
 import {
   PORT_INCREMENT,
@@ -313,10 +313,16 @@ async function distributeAllEnvVars(
     }
   }
 
+  // Check if any package in the monorepo uses Supabase (for internal package detection)
+  const monorepoHasSupabase = hasSupabaseInMonorepo(cwd);
+
   // Distribute to ALL workspaces
   for (const workspace of workspaces) {
     const workspacePath = join(cwd, workspace);
-    const usesSupabase = detectSupabaseUsage(workspacePath);
+    // Check if this workspace uses Supabase directly, OR if it's an app that might
+    // depend on internal packages that wrap Supabase
+    const usesSupabase = detectSupabaseUsage(workspacePath) ||
+                         (workspace.startsWith('apps/') && monorepoHasSupabase);
 
     // Only include Supabase vars if workspace actually uses them
     const varsToDistribute = usesSupabase

--- a/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/env-sync.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/env-sync.ts
@@ -13,7 +13,7 @@
  * @module env-sync
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, readdirSync } from 'fs';
 import { join } from 'path';
 
 /**
@@ -23,6 +23,10 @@ export type WorkspaceFramework = 'nextjs' | 'vite' | 'cloudflare' | 'unknown';
 
 /**
  * Detect if a workspace uses Supabase by checking dependencies
+ *
+ * Checks for:
+ * 1. Direct Supabase SDK usage (@supabase/supabase-js, @supabase/ssr)
+ * 2. Internal packages that wrap Supabase (@scope/supabase, *supabase*)
  *
  * @param workspacePath - Path to the workspace directory
  * @returns True if the workspace uses Supabase
@@ -40,10 +44,68 @@ export function detectSupabaseUsage(workspacePath: string): boolean {
       ...pkg.devDependencies,
     };
 
-    return '@supabase/supabase-js' in allDeps || '@supabase/ssr' in allDeps;
+    // Check for direct Supabase SDK usage
+    if ('@supabase/supabase-js' in allDeps || '@supabase/ssr' in allDeps) {
+      return true;
+    }
+
+    // Check for internal packages that wrap Supabase
+    // Pattern: @{scope}/supabase, @{scope}/*supabase*, *supabase*
+    for (const dep of Object.keys(allDeps)) {
+      // Match patterns like @nodes-md/supabase, @repo/supabase, my-supabase-wrapper
+      if (
+        dep.endsWith('/supabase') || // @scope/supabase
+        /^@[^/]+\/.*supabase.*$/.test(dep) // @scope/*supabase*
+      ) {
+        return true;
+      }
+    }
+
+    return false;
   } catch {
     return false;
   }
+}
+
+/**
+ * Check if ANY workspace in the monorepo uses Supabase directly
+ *
+ * This is a fallback for monorepos where apps depend on internal packages
+ * that wrap Supabase. If any package in packages/ has @supabase dependencies,
+ * we assume all apps may need the env vars.
+ *
+ * @param cwd - Root directory of the monorepo
+ * @returns True if any package uses Supabase
+ */
+export function hasSupabaseInMonorepo(cwd: string): boolean {
+  const packagesDir = join(cwd, 'packages');
+  if (!existsSync(packagesDir)) {
+    return false;
+  }
+
+  try {
+    const entries = readdirSync(packagesDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      const pkgPath = join(packagesDir, entry.name, 'package.json');
+      if (!existsSync(pkgPath)) continue;
+
+      try {
+        const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
+        const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
+        if ('@supabase/supabase-js' in allDeps || '@supabase/ssr' in allDeps) {
+          return true;
+        }
+      } catch {
+        continue;
+      }
+    }
+  } catch {
+    return false;
+  }
+
+  return false;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixed `detectSupabaseUsage()` to detect internal packages that wrap Supabase (e.g., `@nodes-md/supabase`, `@repo/supabase`)
- Added `hasSupabaseInMonorepo()` function to check if any package in `packages/` uses Supabase
- Updated env var distribution to include apps when monorepo has Supabase dependencies

## Problem

In monorepos with shared internal Supabase packages, apps like `apps/app` depend on `@nodes-md/supabase` instead of `@supabase/supabase-js` directly. The previous detection only checked for direct Supabase dependencies, causing env vars to not be written to these apps.

**Before:**
```
✓ Environment variables (Vercel) written to apps/app/.env.local        ← Missing Supabase!
✓ Environment variables (Supabase + Vercel) written to apps/mcp/dev.vars
✓ Environment variables (Vercel) written to apps/web/.env.local        ← Missing Supabase!
```

**After:**
```
✓ Environment variables (Supabase + Vercel) written to apps/app/.env.local
✓ Environment variables (Supabase + Vercel) written to apps/mcp/dev.vars
✓ Environment variables (Supabase + Vercel) written to apps/web/.env.local
```

## Test plan

- [x] TypeScript compiles without errors
- [x] ESLint passes
- [x] Manual test: `detectSupabaseUsage()` returns `true` for apps using internal Supabase packages
- [x] Manual test: `hasSupabaseInMonorepo()` returns `true` when packages/supabase exists
- [x] Manual test: Verified env vars written correctly to nodes-md worktree apps

Closes #261
Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)