### PR TITLE
fix(nextjs-supabase-ai-sdk-dev): Use /tmp/ directory for Supabase config and fix port management

### DIFF
--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/cleanup-supabase-session.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/cleanup-supabase-session.ts
@@ -1,8 +1,8 @@
 /**
  * Supabase Session Cleanup Hook (SessionEnd)
  * SessionEnd hook that:
- * 1. Stops Supabase containers for the current session
- * 2. Restores config.toml from backup (for worktree sessions)
+ * 1. Stops Supabase containers for the current session (using --workdir for tmp configs)
+ * 2. Cleans up /tmp/supabase-{worktreeId} directory
  * 3. Marks session state as stopped
  *
  * This is the primary cleanup hook that runs when the user exits the session
@@ -19,10 +19,7 @@ import {
   loadWorktreeSupabaseSession,
   updateWorktreeSupabaseSession,
 } from '../shared/hooks/utils/session-state.js';
-import {
-  restoreSupabaseConfig,
-  getSupabaseConfigPath,
-} from '../shared/hooks/utils/supabase-ports.js';
+import { cleanupTmpSupabaseDir } from '../shared/hooks/utils/supabase-tmp-config.js';
 import { killProcessesOnPorts } from '../shared/hooks/utils/port.js';
 import { exec } from 'child_process';
 import { promisify } from 'util';
@@ -86,15 +83,32 @@ async function handler(input: SessionEndInput): Promise<SessionEndHookOutput> {
   let cleanedContainers = false;
   let cleanedPorts = false;
   let cleanedConfig = false;
+  let cleanedVolumes = false;
+
+  // 0. Try supabase stop --workdir first (cleanest approach for tmp directory sessions)
+  if (session?.tmpConfigDir && existsSync(session.tmpConfigDir)) {
+    try {
+      const stopResult = await execCommand(
+        `supabase stop --workdir ${session.tmpConfigDir}`,
+        { cwd: input.cwd, timeout: 60000 }
+      );
+      if (stopResult.success) {
+        cleanedContainers = true;
+        cleanedVolumes = true;
+      }
+    } catch {
+      // Fall through to docker-based cleanup
+    }
+  }
 
   // 1. Stop and delete Supabase containers using exact IDs from docker-containers.json
   // This prevents accidentally deleting containers from other sessions
-  let cleanedVolumes = false;
+  // Skip if supabase stop already succeeded
   const dockerConfigPath = join(input.cwd, '.claude', 'logs', 'docker-containers.json');
 
   // Try to use exact container IDs first (more precise, prevents cross-session deletion)
   let usedExactIds = false;
-  if (existsSync(dockerConfigPath)) {
+  if (!cleanedContainers && existsSync(dockerConfigPath)) {
     try {
       const configContent = readFileSync(dockerConfigPath, 'utf-8');
       const dockerConfig: DockerContainerConfig = JSON.parse(configContent);
@@ -123,7 +137,8 @@ async function handler(input: SessionEndInput): Promise<SessionEndHookOutput> {
 
   // Fallback: use filter-based cleanup if exact IDs not available
   // This is less precise but ensures cleanup still happens
-  if (!usedExactIds && session?.worktreeProjectId) {
+  // Skip if supabase stop or exact IDs already succeeded
+  if (!cleanedContainers && !usedExactIds && session?.worktreeProjectId) {
     try {
       // Use exact name matching by listing containers and filtering in shell
       // The filter pattern matches containers ending with the exact project ID
@@ -183,11 +198,10 @@ async function handler(input: SessionEndInput): Promise<SessionEndHookOutput> {
     // Best effort
   }
 
-  // 4. Restore config.toml from backup (for worktree sessions)
-  if (session?.configBackupPath && existsSync(session.configBackupPath)) {
+  // 4. Clean up tmp Supabase config directory (for worktree sessions)
+  if (session?.tmpConfigDir) {
     try {
-      const configPath = getSupabaseConfigPath(input.cwd);
-      restoreSupabaseConfig(configPath, `.backup-${worktreeInfo.worktreeId}`);
+      cleanupTmpSupabaseDir(session.tmpConfigDir);
       cleanedConfig = true;
     } catch {
       // Best effort

--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/install-start-supabase-next.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/install-start-supabase-next.ts
@@ -16,6 +16,7 @@ import { runHook } from '../shared/hooks/utils/io.js';
 import { detectPackageManager } from '../shared/hooks/utils/package-manager.js';
 import { isPortAvailable, findAvailablePort, killProcessOnPort, findAvailablePortAt10Increments } from '../shared/hooks/utils/port.js';
 import { getWranglerDevPort } from '../shared/hooks/utils/toml.js';
+import { findViteConfigPort } from '../shared/hooks/utils/vite-config.js';
 import { distributeEnvVars, mergeWorkspaceEnvVars, validateEnvVars, detectSupabaseUsage, hasSupabaseInMonorepo, generateAppUrls, detectWorkspaceFramework, type DevServerPorts, type WorkspaceInfo } from '../shared/hooks/utils/env-sync.js';
 import { detectWorktree, type WorktreeInfo } from '../shared/hooks/utils/worktree.js';
 import {
@@ -23,14 +24,16 @@ import {
   calculatePortSet,
   checkSupabasePortUsage,
   findAvailableSlot,
-  updateSupabaseConfigPorts,
   getSupabaseConfigPath,
   getOriginalProjectId,
   generateWorktreeProjectId,
-  updateSupabaseProjectId,
   buildExcludeFlags,
   type SupabasePortSet,
 } from '../shared/hooks/utils/supabase-ports.js';
+import {
+  createTmpSupabaseDir,
+  addToGitignore,
+} from '../shared/hooks/utils/supabase-tmp-config.js';
 import {
   loadWorktreeSupabaseSession,
   saveWorktreeSupabaseSession,
@@ -213,26 +216,22 @@ async function isSupabaseRunning(cwd: string): Promise<boolean> {
 }
 
 /**
- * Start Supabase local server
- */
-async function startSupabase(cwd: string): Promise<ExecResult> {
-  // 5 minute timeout for first run (downloads containers)
-  return await execCommand('supabase start', { cwd, timeout: 300000 });
-}
-
-/**
  * Export Supabase env vars to .env.local and dev.vars
  * Only saves 3 critical variables with correct prefixes
  * Maps deprecated variable names to modern ones
  *
  * @param supabaseRoot - Directory containing supabase/config.toml (where to run supabase CLI)
+ * @param workdir - Optional workdir path (for tmp directory approach)
  * @returns Object with vars, success status, and deprecation warnings
  */
 async function exportSupabaseEnvVars(
-  supabaseRoot: string
+  supabaseRoot: string,
+  workdir?: string
 ): Promise<{ vars: Record<string, string>; success: boolean; warnings: string[] }> {
   // Get raw env output from supabase root
-  const result = await execCommand('supabase status -o env', { cwd: supabaseRoot, timeout: 10000 });
+  // Use --workdir if tmp directory is provided
+  const workdirFlag = workdir ? ` --workdir ${workdir}` : '';
+  const result = await execCommand(`supabase status -o env${workdirFlag}`, { cwd: supabaseRoot, timeout: 10000 });
   if (!result.success) {
     return { vars: {}, success: false, warnings: [] };
   }
@@ -489,6 +488,11 @@ async function detectWorkspacePorts(cwd: string, workspaces: string[]): Promise<
       configuredPort = await getWranglerDevPort(wranglerTomlPath) ||
                        await getWranglerDevPort(wranglerJsoncPath) ||
                        null;
+    }
+
+    // For Vite projects, check vite.config.ts for server.port
+    if (configuredPort === null && wsProjectType === 'vite') {
+      configuredPort = findViteConfigPort(workspacePath);
     }
 
     // Get default port for this project type
@@ -1343,8 +1347,9 @@ async function findAvailableContainerName(baseProjectId: string): Promise<{ name
 }
 
 /**
- * Start Supabase with custom ports (for worktree instances)
- * Modifies config.toml, starts Supabase, and saves session state
+ * Start Supabase with custom ports using /tmp/ directory
+ * Creates a temporary config directory with symlinks, starts Supabase, and saves session state.
+ * Does NOT modify the original config.toml.
  */
 async function startWorktreeSupabase(
   cwd: string,
@@ -1354,10 +1359,11 @@ async function startWorktreeSupabase(
   worktreeInfo: WorktreeInfo,
   messages: string[],
   sessionId: string
-): Promise<{ success: boolean; configBackupPath?: string; projectId?: string }> {
+): Promise<{ success: boolean; tmpConfigDir?: string; projectId?: string }> {
   const configPath = getSupabaseConfigPath(cwd);
+  const originalSupabaseDir = join(cwd, 'supabase');
 
-  // Read original project_id (tries backup first to avoid cascading suffixes)
+  // Read original project_id from config.toml
   const originalProjectId = getOriginalProjectId(configPath, worktreeInfo.worktreeId);
   if (!originalProjectId) {
     messages.push('⚠️ Could not read project_id from config.toml');
@@ -1367,52 +1373,45 @@ async function startWorktreeSupabase(
   // Generate worktree-specific project_id
   const worktreeProjectId = generateWorktreeProjectId(originalProjectId, slot);
 
-  let configBackupPath: string | undefined;
-
-  // Update config for worktrees (slot > 0)
-  if (slot > 0) {
-    try {
-      const backupSuffix = `.backup-${worktreeInfo.worktreeId}`;
-
-      // Update BOTH project_id and ports in config.toml
-      configBackupPath = updateSupabaseProjectId(configPath, worktreeProjectId, backupSuffix);
-      updateSupabaseConfigPorts(configPath, supabasePorts, ''); // Ports already updated
-
-      messages.push(`✓ Updated config.toml for worktree slot ${slot}`);
-      messages.push(`  Project ID: ${originalProjectId} → ${worktreeProjectId}`);
-      messages.push(`  Backup: ${configBackupPath}`);
-    } catch (error) {
-      messages.push(`⚠️ Failed to update config.toml: ${error}`);
-      return { success: false };
-    }
-  } else {
-    // Main repo - still update ports but keep original project_id
-    try {
-      const backupSuffix = `.backup-main`;
-      configBackupPath = updateSupabaseConfigPorts(configPath, supabasePorts, backupSuffix);
-      messages.push(`✓ Using default project_id: ${originalProjectId}`);
-    } catch (error) {
-      messages.push(`⚠️ Failed to update ports: ${error}`);
-      return { success: false };
-    }
+  // Create temporary Supabase directory with symlinks
+  let tmpConfig;
+  try {
+    tmpConfig = createTmpSupabaseDir(
+      worktreeInfo.worktreeId,
+      originalSupabaseDir,
+      worktreeProjectId,
+      supabasePorts
+    );
+    messages.push(`✓ Created temporary Supabase config at ${tmpConfig.tmpDir}`);
+    messages.push(`  Project ID: ${originalProjectId} → ${worktreeProjectId}`);
+    messages.push(`  Symlinks: seed.sql, migrations/, functions/, templates/`);
+  } catch (error) {
+    messages.push(`⚠️ Failed to create tmp config directory: ${error}`);
+    return { success: false };
   }
 
-  // Build exclude flags for disabled services
-  const excludeFlags = buildExcludeFlags(configPath);
-  const startCommand = `supabase start${excludeFlags}`;
+  // Add to .gitignore if needed
+  const addedToGitignore = addToGitignore(cwd);
+  if (addedToGitignore) {
+    messages.push('✓ Added /tmp/supabase-* to .gitignore');
+  }
+
+  // Build exclude flags for disabled services (using tmp config)
+  const excludeFlags = buildExcludeFlags(tmpConfig.configPath);
+  const startCommand = `supabase start --workdir ${tmpConfig.tmpDir}${excludeFlags}`;
 
   if (excludeFlags) {
     const excluded = excludeFlags.replace(' --exclude ', '').split(',');
     messages.push(`⚡ Optimized: Skipping services: ${excluded.join(', ')}`);
   }
 
-  // Start Supabase
+  // Start Supabase using the tmp directory
   messages.push(`Starting Supabase: ${startCommand}`);
-  const startResult = await startSupabase(cwd);
+  const startResult = await execCommand(startCommand, { cwd, timeout: 300000 });
 
   if (!startResult.success) {
     messages.push(`⚠️ Failed to start Supabase: ${startResult.stderr}`);
-    return { success: false, configBackupPath };
+    return { success: false, tmpConfigDir: tmpConfig.tmpDir };
   }
 
   messages.push('✓ Supabase started with isolated containers');
@@ -1420,6 +1419,7 @@ async function startWorktreeSupabase(
   messages.push(`  Containers: supabase_*_${worktreeProjectId}`);
   messages.push(`  API: http://localhost:${supabasePorts.api}`);
   messages.push(`  Studio: http://localhost:${supabasePorts.studio}`);
+  messages.push(`  Inbucket (email): http://localhost:${supabasePorts.inbucket}`);
 
   // Save exact container IDs for scoped cleanup in SessionEnd hook
   // This prevents accidentally deleting containers from other sessions
@@ -1439,6 +1439,7 @@ async function startWorktreeSupabase(
           `supabase_db_${worktreeProjectId}`,
           `supabase_storage_${worktreeProjectId}`,
         ],
+        tmpConfigDir: tmpConfig.tmpDir,
         savedAt: new Date().toISOString(),
       };
       writeFileSync(dockerConfigPath, JSON.stringify(dockerConfig, null, 2));
@@ -1449,7 +1450,7 @@ async function startWorktreeSupabase(
     messages.push('  ⚠️ Could not save container IDs (cleanup may be less precise)');
   }
 
-  // Save session state with project IDs
+  // Save session state with project IDs and tmp directory
   const session: WorktreeSupabaseSession = {
     worktreeId: worktreeInfo.worktreeId,
     worktreePath: worktreeInfo.worktreePath,
@@ -1457,16 +1458,18 @@ async function startWorktreeSupabase(
     supabasePorts,
     devServerPorts,
     startedAt: new Date().toISOString(),
-    configBackupPath: configBackupPath || '',
+    configBackupPath: '', // No longer using backups - using tmp dir instead
     running: true,
     originalProjectId,
     worktreeProjectId,
     sessionId,
+    tmpConfigDir: tmpConfig.tmpDir,
+    originalSupabaseDir,
   };
 
   await saveWorktreeSupabaseSession(cwd, session);
 
-  return { success: true, configBackupPath, projectId: worktreeProjectId };
+  return { success: true, tmpConfigDir: tmpConfig.tmpDir, projectId: worktreeProjectId };
 }
 
 // ==================== Dependency Installation ====================
@@ -1668,6 +1671,8 @@ async function handler(input: SessionStartInput): Promise<SessionStartHookOutput
     let supabaseRunning = false;
     // Track worktree slot for dev server port allocation (slot 0 = default, slot N = +N*10 offset)
     const worktreeSlot = instanceConfig.slot;
+    // Track tmp config directory for supabase status commands
+    let supabaseTmpDir: string | undefined;
 
     if (dockerRunning) {
       if (instanceConfig.needsNewInstance) {
@@ -1683,12 +1688,14 @@ async function handler(input: SessionStartInput): Promise<SessionStartHookOutput
           input.session_id
         );
         supabaseRunning = startResult.success;
+        supabaseTmpDir = startResult.tmpConfigDir;
       } else if (instanceConfig.existingSession) {
         // Use existing worktree session
         messages.push('✓ Supabase already running (worktree session)');
         messages.push(`  API: http://localhost:${instanceConfig.supabasePorts.api}`);
         messages.push(`  Studio: http://localhost:${instanceConfig.supabasePorts.studio}`);
         supabaseRunning = true;
+        supabaseTmpDir = instanceConfig.existingSession.tmpConfigDir;
       } else {
         // Check if default Supabase is running
         const supabaseInfo = await detectSharedSupabase(input.cwd);
@@ -1716,7 +1723,7 @@ async function handler(input: SessionStartInput): Promise<SessionStartHookOutput
         // Collect Supabase vars if running
         let supabaseVars: Record<string, string> | undefined;
         if (supabaseRunning) {
-          const result = await exportSupabaseEnvVars(input.cwd);
+          const result = await exportSupabaseEnvVars(input.cwd, supabaseTmpDir);
           if (result.success) {
             supabaseVars = result.vars;
             // Show deprecation warnings if any
@@ -1732,7 +1739,7 @@ async function handler(input: SessionStartInput): Promise<SessionStartHookOutput
       }
     } else if (supabaseRunning) {
       // For single projects: export Supabase vars to root
-      const result = await exportSupabaseEnvVars(input.cwd);
+      const result = await exportSupabaseEnvVars(input.cwd, supabaseTmpDir);
       if (result.success && Object.keys(result.vars).length > 0) {
         // Show deprecation warnings if any
         if (result.warnings.length > 0) {

--- a/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/port.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/port.ts
@@ -222,3 +222,137 @@ export async function findAvailablePortAt10Increments(
   }
   return null;
 }
+
+// ============================================================================
+// App Port Configuration Types and Functions
+// ============================================================================
+
+/**
+ * Project type for port defaults
+ */
+export type ProjectType = 'nextjs' | 'cloudflare' | 'vite' | 'elysia' | 'turborepo' | 'unknown';
+
+/**
+ * Port configuration for a single app/workspace
+ */
+export interface AppPortConfig {
+  /** Path to the app/workspace */
+  workspace: string;
+  /** Detected project type */
+  projectType: ProjectType;
+  /** Port from config file (--port flag, wrangler.toml, vite.config.ts) */
+  configuredPort: number | null;
+  /** Default port for this project type */
+  defaultPort: number;
+  /** Final resolved port to use (after availability check) */
+  resolvedPort: number;
+}
+
+/**
+ * Default ports for each project type
+ */
+export const DEFAULT_PORTS: Record<ProjectType, number> = {
+  nextjs: 3000,
+  cloudflare: 8787,
+  vite: 5173,
+  elysia: 3000,
+  turborepo: 3000,
+  unknown: 3000,
+};
+
+/**
+ * Get the default port for a project type
+ *
+ * @param projectType - Type of project
+ * @returns Default port number
+ */
+export function getDefaultPort(projectType: ProjectType): number {
+  return DEFAULT_PORTS[projectType] ?? 3000;
+}
+
+/**
+ * Resolve ports for multiple apps, checking availability sequentially
+ *
+ * For each app:
+ * 1. Try configuredPort (from config file) if set
+ * 2. Fall back to defaultPort for project type
+ * 3. If that port is unavailable, find next port at +10 increments
+ *
+ * Apps are processed sequentially to avoid allocating the same port twice.
+ * Claimed ports are tracked internally to prevent conflicts.
+ *
+ * @param apps - Array of app port configurations (mutated with resolvedPort)
+ * @returns Promise resolving to the same array with resolvedPort filled in
+ *
+ * @example
+ * ```typescript
+ * const apps: AppPortConfig[] = [
+ *   { workspace: 'apps/web', projectType: 'nextjs', configuredPort: null, defaultPort: 3000, resolvedPort: 0 },
+ *   { workspace: 'apps/api', projectType: 'cloudflare', configuredPort: 8787, defaultPort: 8787, resolvedPort: 0 },
+ * ];
+ *
+ * await resolveAppPorts(apps);
+ * // apps[0].resolvedPort = 3000 (or 3010 if 3000 was in use)
+ * // apps[1].resolvedPort = 8787 (or 8797 if 8787 was in use)
+ * ```
+ */
+export async function resolveAppPorts(apps: AppPortConfig[]): Promise<AppPortConfig[]> {
+  // Track ports we've already claimed in this resolution
+  const claimedPorts = new Set<number>();
+
+  for (const app of apps) {
+    // Determine the preferred port (configured or default)
+    const preferredPort = app.configuredPort ?? app.defaultPort;
+
+    // Check if preferred port is available and not already claimed
+    const preferredAvailable = await isPortAvailable(preferredPort);
+    if (preferredAvailable && !claimedPorts.has(preferredPort)) {
+      app.resolvedPort = preferredPort;
+      claimedPorts.add(preferredPort);
+      continue;
+    }
+
+    // Port not available, find next at +10 increments
+    const resolvedPort = await findAvailablePortAt10IncrementsExcluding(
+      preferredPort,
+      claimedPorts,
+      25
+    );
+
+    if (resolvedPort !== null) {
+      app.resolvedPort = resolvedPort;
+      claimedPorts.add(resolvedPort);
+    } else {
+      // Fallback: use preferred port anyway (will likely fail at runtime)
+      app.resolvedPort = preferredPort;
+    }
+  }
+
+  return apps;
+}
+
+/**
+ * Find available port at +10 increments, excluding already claimed ports
+ *
+ * @param basePort - Starting port
+ * @param excludePorts - Set of ports to skip
+ * @param maxSlots - Maximum slots to check
+ * @returns Available port, or null if none found
+ */
+async function findAvailablePortAt10IncrementsExcluding(
+  basePort: number,
+  excludePorts: Set<number>,
+  maxSlots: number = 25
+): Promise<number | null> {
+  for (let slot = 0; slot < maxSlots; slot++) {
+    const port = basePort + slot * 10;
+    if (excludePorts.has(port)) {
+      continue;
+    }
+    const available = await isPortAvailable(port);
+    if (available) {
+      return port;
+    }
+  }
+  return null;
+}

--- a/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/session-state.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/session-state.ts
@@ -332,7 +332,7 @@ export interface WorktreeSupabaseSession {
   devServerPorts: DevServerPortSet;
   /** ISO timestamp when instance was started */
   startedAt: string;
-  /** Path to config.toml backup file */
+  /** Path to config.toml backup file (deprecated - use tmpConfigDir) */
   configBackupPath: string;
   /** Whether instance is currently running */
   running: boolean;
@@ -342,6 +342,10 @@ export interface WorktreeSupabaseSession {
   worktreeProjectId: string;
   /** Claude session ID that owns this instance (for orphan detection) */
   sessionId?: string;
+  /** Path to temporary Supabase config directory (e.g., /tmp/supabase-abc12345) */
+  tmpConfigDir?: string;
+  /** Path to original supabase/ directory in project */
+  originalSupabaseDir?: string;
 }
 
 // ============================================================================

--- a/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/supabase-tmp-config.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/supabase-tmp-config.ts
@@ -1,0 +1,307 @@
+/**
+ * Supabase Temporary Config Directory Utility
+ * Manages /tmp/ directories for Supabase config to avoid modifying checked-in files.
+ * Uses symlinks for migrations, seed.sql, functions, and templates.
+ * @module supabase-tmp-config
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync, symlinkSync, rmSync, readdirSync, appendFileSync } from 'fs';
+import { join } from 'path';
+import type { SupabasePortSet } from './supabase-ports.js';
+
+/**
+ * Configuration for a temporary Supabase directory
+ */
+export interface TmpSupabaseConfig {
+  /** Path to the tmp directory (e.g., /tmp/supabase-abc12345) */
+  tmpDir: string;
+  /** Path to config.toml in tmp directory */
+  configPath: string;
+  /** Path to original supabase/ directory */
+  originalDir: string;
+  /** Modified project_id for this instance */
+  projectId: string;
+  /** Assigned ports for this instance */
+  ports: SupabasePortSet;
+}
+
+/**
+ * Items to symlink from original supabase/ directory
+ * These stay in sync with the original project
+ */
+const SYMLINK_ITEMS = ['seed.sql', 'migrations', 'functions', 'templates'] as const;
+
+
+/**
+ * Generate the tmp directory path for a worktree
+ * Uses a normalized worktree ID for consistency
+ *
+ * @param worktreeId - The worktree identifier (8-char hash or similar)
+ * @returns Path to tmp directory (e.g., /tmp/supabase-abc12345)
+ */
+export function getTmpSupabasePath(worktreeId: string): string {
+  // Normalize worktree ID to lowercase alphanumeric with dashes
+  const normalizedId = worktreeId.toLowerCase().replace(/[^a-z0-9-]/g, '');
+  return `/tmp/supabase-${normalizedId}`;
+}
+
+/**
+ * Create a fresh temporary Supabase directory with symlinks
+ * Cleans up any existing directory first (fresh each session)
+ *
+ * @param worktreeId - The worktree identifier
+ * @param originalSupabaseDir - Path to original supabase/ directory
+ * @param projectId - Project ID to use in config
+ * @param ports - Port set to configure
+ * @returns Configuration for the tmp directory
+ * @throws Error if original directory doesn't exist or can't create tmp
+ */
+export function createTmpSupabaseDir(
+  worktreeId: string,
+  originalSupabaseDir: string,
+  projectId: string,
+  ports: SupabasePortSet
+): TmpSupabaseConfig {
+  const tmpDir = getTmpSupabasePath(worktreeId);
+
+  // Verify original directory exists
+  if (!existsSync(originalSupabaseDir)) {
+    throw new Error(`Original Supabase directory not found: ${originalSupabaseDir}`);
+  }
+
+  const originalConfigPath = join(originalSupabaseDir, 'config.toml');
+  if (!existsSync(originalConfigPath)) {
+    throw new Error(`Original config.toml not found: ${originalConfigPath}`);
+  }
+
+  // Clean up existing tmp directory (fresh each session)
+  if (existsSync(tmpDir)) {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+
+  // Create tmp directory
+  mkdirSync(tmpDir, { recursive: true });
+
+  // Create symlinks for allowed items
+  createSymlinks(tmpDir, originalSupabaseDir);
+
+  // Copy and update config.toml
+  const tmpConfigPath = join(tmpDir, 'config.toml');
+  copyAndUpdateConfig(originalConfigPath, tmpConfigPath, projectId, ports);
+
+  return {
+    tmpDir,
+    configPath: tmpConfigPath,
+    originalDir: originalSupabaseDir,
+    projectId,
+    ports,
+  };
+}
+
+/**
+ * Create symlinks from tmp directory to original supabase/ items
+ * Only symlinks items that exist in original directory
+ *
+ * @param tmpDir - Tmp directory to create symlinks in
+ * @param originalDir - Original supabase/ directory
+ */
+export function createSymlinks(tmpDir: string, originalDir: string): void {
+  for (const item of SYMLINK_ITEMS) {
+    const originalPath = join(originalDir, item);
+    const tmpPath = join(tmpDir, item);
+
+    // Only create symlink if original exists
+    if (existsSync(originalPath)) {
+      try {
+        symlinkSync(originalPath, tmpPath, 'junction');
+      } catch (err) {
+        // Fallback to regular symlink if junction fails (non-Windows)
+        try {
+          symlinkSync(originalPath, tmpPath);
+        } catch {
+          // If symlink fails entirely, skip this item
+          console.error(`Warning: Could not create symlink for ${item}: ${err}`);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Copy config.toml and update with new project_id and ports
+ *
+ * @param originalConfigPath - Path to original config.toml
+ * @param tmpConfigPath - Path to write updated config
+ * @param projectId - New project_id to set
+ * @param ports - Port values to set
+ */
+export function copyAndUpdateConfig(
+  originalConfigPath: string,
+  tmpConfigPath: string,
+  projectId: string,
+  ports: SupabasePortSet
+): void {
+  let content = readFileSync(originalConfigPath, 'utf-8');
+
+  // Update project_id
+  content = content.replace(
+    /^(\s*project_id\s*=\s*)"[^"]*"/m,
+    `$1"${projectId}"`
+  );
+
+  // Update ports using helper function
+  content = updateConfigPorts(content, ports);
+
+  writeFileSync(tmpConfigPath, content, 'utf-8');
+}
+
+/**
+ * Update port values in config.toml content
+ *
+ * @param content - Config.toml content
+ * @param ports - New port values
+ * @returns Updated content
+ */
+function updateConfigPorts(content: string, ports: SupabasePortSet): string {
+  // Helper to update a port value in a section
+  const updatePort = (sectionPattern: string, key: string, value: number): void => {
+    // Pattern to match [section] followed by key = value
+    const regex = new RegExp(
+      `(\\[${sectionPattern}\\][\\s\\S]*?)(^\\s*${key}\\s*=\\s*)(\\d+)`,
+      'gm'
+    );
+
+    if (regex.test(content)) {
+      regex.lastIndex = 0;
+      content = content.replace(regex, `$1$2${value}`);
+    }
+  };
+
+  // Update each port
+  updatePort('api', 'port', ports.api);
+  updatePort('db', 'port', ports.db);
+  updatePort('db', 'shadow_port', ports.shadowDb);
+  updatePort('db\\.pooler', 'port', ports.pooler);
+  updatePort('studio', 'port', ports.studio);
+  updatePort('inbucket', 'port', ports.inbucket);
+  updatePort('analytics', 'port', ports.analytics);
+  updatePort('edge_runtime', 'inspector_port', ports.edgeRuntime);
+
+  return content;
+}
+
+/**
+ * Clean up a temporary Supabase directory
+ * Safe to call even if directory doesn't exist
+ *
+ * @param tmpDir - Path to tmp directory to remove
+ */
+export function cleanupTmpSupabaseDir(tmpDir: string): void {
+  if (existsSync(tmpDir)) {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch (err) {
+      console.error(`Warning: Could not clean up tmp directory ${tmpDir}: ${err}`);
+    }
+  }
+}
+
+/**
+ * Add tmp directory pattern to .gitignore if not already present
+ *
+ * @param projectRoot - Project root directory (where .gitignore is)
+ * @param tmpPath - Tmp directory path to add (will be converted to pattern)
+ * @returns true if pattern was added, false if already present
+ */
+export function addToGitignore(projectRoot: string, _tmpPath?: string): boolean {
+  const gitignorePath = join(projectRoot, '.gitignore');
+  const pattern = '/tmp/supabase-*';
+
+  // Check if .gitignore exists
+  if (!existsSync(gitignorePath)) {
+    // Create .gitignore with just this pattern
+    writeFileSync(gitignorePath, `# Supabase temp config directories\n${pattern}\n`, 'utf-8');
+    return true;
+  }
+
+  // Read existing content
+  const content = readFileSync(gitignorePath, 'utf-8');
+
+  // Check if pattern already exists (with various formats)
+  const patterns = [pattern, '/tmp/supabase-', 'tmp/supabase-'];
+  for (const p of patterns) {
+    if (content.includes(p)) {
+      return false; // Already present
+    }
+  }
+
+  // Add pattern at the end
+  const separator = content.endsWith('\n') ? '' : '\n';
+  appendFileSync(gitignorePath, `${separator}\n# Supabase temp config directories\n${pattern}\n`, 'utf-8');
+  return true;
+}
+
+/**
+ * Check if a tmp Supabase directory exists for a worktree
+ *
+ * @param worktreeId - The worktree identifier
+ * @returns true if tmp directory exists
+ */
+export function tmpSupabaseDirExists(worktreeId: string): boolean {
+  const tmpDir = getTmpSupabasePath(worktreeId);
+  return existsSync(tmpDir);
+}
+
+/**
+ * Get the config.toml path for a tmp Supabase directory
+ *
+ * @param worktreeId - The worktree identifier
+ * @returns Path to config.toml in tmp directory
+ */
+export function getTmpConfigPath(worktreeId: string): string {
+  return join(getTmpSupabasePath(worktreeId), 'config.toml');
+}
+
+/**
+ * List all tmp Supabase directories currently on the system
+ * Useful for cleanup and diagnostics
+ *
+ * @returns Array of tmp directory paths
+ */
+export function listTmpSupabaseDirs(): string[] {
+  const tmpDir = '/tmp';
+  if (!existsSync(tmpDir)) {
+    return [];
+  }
+
+  try {
+    const entries = readdirSync(tmpDir, { withFileTypes: true });
+    return entries
+      .filter(entry => entry.isDirectory() && entry.name.startsWith('supabase-'))
+      .map(entry => join(tmpDir, entry.name));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Clean up all tmp Supabase directories
+ * Use with caution - will remove all instances
+ *
+ * @returns Number of directories cleaned up
+ */
+export function cleanupAllTmpSupabaseDirs(): number {
+  const dirs = listTmpSupabaseDirs();
+  let cleaned = 0;
+
+  for (const dir of dirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+      cleaned++;
+    } catch {
+      // Continue with other directories
+    }
+  }
+
+  return cleaned;
+}

--- a/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/vite-config.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/vite-config.ts
@@ -1,0 +1,117 @@
+/**
+ * Vite Configuration Parser Utility
+ * Parses vite.config.ts files to extract server.port configuration.
+ * @module vite-config
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Default Vite dev server port
+ */
+export const VITE_DEFAULT_PORT = 5173;
+
+/**
+ * Parse vite.config.ts/js/mjs to extract server.port value
+ * Uses regex to extract port from various config patterns:
+ * - server: { port: 3000 }
+ * - server: { port: Number(3000) }
+ * - defineConfig({ server: { port: 3000 } })
+ *
+ * @param viteConfigPath - Path to vite.config.ts/js/mjs file
+ * @returns Configured port number, or null if not found
+ * @example
+ * ```typescript
+ * const port = getViteConfigPort('/path/to/vite.config.ts');
+ * // Returns: 3000 (if configured) or null (if not found)
+ * ```
+ */
+export function getViteConfigPort(viteConfigPath: string): number | null {
+  if (!existsSync(viteConfigPath)) {
+    return null;
+  }
+
+  try {
+    const content = readFileSync(viteConfigPath, 'utf-8');
+
+    // Pattern 1: server: { port: 3000 } or server: { port: 3000, ... }
+    // Handles multiline and various whitespace
+    const serverBlockMatch = content.match(
+      /server\s*:\s*\{[^}]*port\s*:\s*(\d+)/s
+    );
+    if (serverBlockMatch) {
+      return parseInt(serverBlockMatch[1], 10);
+    }
+
+    // Pattern 2: server.port = 3000 (less common but valid)
+    const dotNotationMatch = content.match(
+      /server\.port\s*[=:]\s*(\d+)/
+    );
+    if (dotNotationMatch) {
+      return parseInt(dotNotationMatch[1], 10);
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find and parse vite.config file in a directory
+ * Tries .ts, .js, .mjs extensions in order
+ *
+ * @param workspacePath - Directory to search for vite config
+ * @returns Configured port number, or null if not found
+ * @example
+ * ```typescript
+ * const port = findViteConfigPort('/path/to/project');
+ * // Searches for vite.config.ts, vite.config.js, vite.config.mjs
+ * ```
+ */
+export function findViteConfigPort(workspacePath: string): number | null {
+  const extensions = ['ts', 'js', 'mjs'];
+
+  for (const ext of extensions) {
+    const configPath = join(workspacePath, `vite.config.${ext}`);
+    const port = getViteConfigPort(configPath);
+    if (port !== null) {
+      return port;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Check if a directory contains a Vite configuration file
+ *
+ * @param workspacePath - Directory to check
+ * @returns true if vite.config.{ts,js,mjs} exists
+ */
+export function hasViteConfig(workspacePath: string): boolean {
+  const extensions = ['ts', 'js', 'mjs'];
+  return extensions.some(ext =>
+    existsSync(join(workspacePath, `vite.config.${ext}`))
+  );
+}
+
+/**
+ * Get the path to the vite config file if it exists
+ *
+ * @param workspacePath - Directory to search
+ * @returns Path to vite config file, or null if not found
+ */
+export function getViteConfigPath(workspacePath: string): string | null {
+  const extensions = ['ts', 'js', 'mjs'];
+
+  for (const ext of extensions) {
+    const configPath = join(workspacePath, `vite.config.${ext}`);
+    if (existsSync(configPath)) {
+      return configPath;
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- Uses `/tmp/supabase-{worktreeId}` directory with symlinks instead of modifying checked-in config.toml
- Adds vite.config.ts port parsing for Vite projects
- Uses config-defined ports first with +10 fallback if unavailable
- Fixes SUPABASE_URL export to use correct API port via --workdir flag
- Updates cleanup hook to stop Supabase with --workdir and clean up tmp directories

## Changes

### New Files
- `supabase-tmp-config.ts` - Manages /tmp/ directories with symlinks to migrations, seed.sql, functions, templates
- `vite-config.ts` - Parses vite.config.ts for server.port configuration

### Modified Files
- `port.ts` - Added `resolveAppPorts()` for sequential port allocation with config-defined ports first
- `session-state.ts` - Added `tmpConfigDir` and `originalSupabaseDir` fields
- `install-start-supabase-next.ts` - Refactored to use tmp directory approach, added vite port detection
- `cleanup-supabase-session.ts` - Uses `supabase stop --workdir` and cleans up tmp directories

## Test plan

- [ ] Verify Supabase starts with correct ports in a worktree session
- [ ] Verify `/tmp/supabase-{id}` is created with correct symlinks
- [ ] Verify SUPABASE_URL env var is set to correct API port (54321+offset)
- [ ] Verify dev servers use config-defined ports or fallback to +10
- [ ] Verify cleanup removes tmp directory on session end

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)