### PR TITLE
fix(nextjs-supabase-ai-sdk-dev): Use config-defined ports for URL generation

### DIFF
--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/install-start-supabase-next.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/install-start-supabase-next.ts
@@ -322,11 +322,13 @@ async function distributeAllEnvVars(
   let appUrlsByWorkspace: Map<string, Record<string, string>> | null = null;
   if (devServerPorts) {
     // Build workspace info for URL generation
+    // Extract configured ports from package.json dev scripts
     const workspaceInfos: WorkspaceInfo[] = workspaces.map(ws => {
       const wsPath = join(cwd, ws);
       const name = ws.split('/').pop() || ws;
       const framework = detectWorkspaceFramework(wsPath);
-      return { path: ws, name, framework };
+      const configuredPort = extractPortFromDevScript(join(wsPath, 'package.json'));
+      return { path: ws, name, framework, configuredPort };
     });
 
     appUrlsByWorkspace = generateAppUrls(workspaceInfos, devServerPorts);
@@ -361,6 +363,9 @@ async function distributeAllEnvVars(
         'SUPABASE_SECRET_KEY',
         'VITE_SUPABASE_URL',
         'VITE_SUPABASE_PUBLISHABLE_KEY',
+        // Cloudflare dev.vars uses unprefixed keys
+        'SUPABASE_URL',
+        'SUPABASE_PUBLISHABLE_KEY',
       );
     }
 

--- a/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/env-sync.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/env-sync.ts
@@ -602,6 +602,8 @@ export interface WorkspaceInfo {
   name: string;
   /** Detected framework type */
   framework: WorkspaceFramework;
+  /** Port configured in package.json dev script (--port flag), or null if not configured */
+  configuredPort: number | null;
 }
 
 /**
@@ -643,7 +645,7 @@ export function generateAppUrls(
   const urlsByWorkspace = new Map<string, Record<string, string>>();
 
   // First, calculate the actual port for each workspace
-  // For multiple apps of the same type, increment port by 1
+  // Use configuredPort if available, otherwise fall back to base + offset
   const portsByType: Record<WorkspaceFramework, number> = {
     nextjs: ports.nextjs,
     vite: ports.vite,
@@ -660,14 +662,23 @@ export function generateAppUrls(
   };
 
   // Assign ports to each workspace
+  // Priority: configuredPort > base port + offset
   for (const ws of workspaces) {
-    const basePort = portsByType[ws.framework];
-    const usedPorts = usedPortsByType[ws.framework];
-    const offset = usedPorts.length;
-    const port = basePort + offset;
+    let port: number;
+
+    if (ws.configuredPort !== null) {
+      // Use the port configured in package.json dev script
+      port = ws.configuredPort;
+    } else {
+      // Fall back to base port + offset for workspaces without configured port
+      const basePort = portsByType[ws.framework];
+      const usedPorts = usedPortsByType[ws.framework];
+      const offset = usedPorts.length;
+      port = basePort + offset;
+    }
 
     workspacePortMap.set(ws.path, port);
-    usedPorts.push(port);
+    usedPortsByType[ws.framework].push(port);
   }
 
   // Generate URL vars for each workspace


### PR DESCRIPTION
## Summary

- Fixes URL generation to use ports configured in package.json dev scripts (e.g., `--port 3100`)
- Previously, URLs were generated using base ports (3000, 3001, 3002...) ignoring actual config
- Adds `configuredPort` field to `WorkspaceInfo` interface
- Adds unprefixed Supabase keys to alwaysOverwriteKeys for Cloudflare dev.vars

## Test plan

- [ ] Clear plugin cache: `rm -rf ~/.claude/plugins/cache/constellos/nextjs-supabase-ai-sdk-dev`
- [ ] Reinstall plugin in nodes-md worktree
- [ ] Start new session and verify env files have correct ports:
  - `NEXT_PUBLIC_APP_URL=http://localhost:3100` (not 3000)
  - `NEXT_PUBLIC_WEB_URL=http://localhost:3101` (not 3001)
  - `NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321` (not 3002)
  - `SUPABASE_URL=http://localhost:54321` in dev.vars

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)