### PR TITLE
fix(nextjs-supabase-ai-sdk-dev): Consistent container naming with -0 suffix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2991,6 +2991,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/install-start-supabase-next.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/install-start-supabase-next.ts
@@ -1323,7 +1323,7 @@ async function cleanupOrphanedSessions(
 
 /**
  * Find the next available Supabase container name based on what's actually running in Docker
- * Returns base name if available, otherwise base-1, base-2, etc.
+ * Always uses suffixed naming: base-0, base-1, base-2, etc. (never bare project name)
  */
 async function findAvailableContainerName(baseProjectId: string): Promise<{ name: string; slot: number }> {
   try {
@@ -1343,13 +1343,9 @@ async function findAvailableContainerName(baseProjectId: string): Promise<{ name
       }
     }
 
-    // Try base name first (e.g., "constellos")
-    if (!runningProjectIds.has(baseProjectId)) {
-      return { name: baseProjectId, slot: 0 };
-    }
-
-    // Find next available suffix: constellos-1, constellos-2, etc.
-    for (let i = 1; i < 10; i++) {
+    // Find next available suffix: constellos-0, constellos-1, constellos-2, etc.
+    // Always use -N suffix for consistent naming (never bare project name)
+    for (let i = 0; i < 10; i++) {
       const candidate = `${baseProjectId}-${i}`;
       if (!runningProjectIds.has(candidate)) {
         return { name: candidate, slot: i };
@@ -1357,10 +1353,10 @@ async function findAvailableContainerName(baseProjectId: string): Promise<{ name
     }
 
     // All slots taken, fall back to slot 0 (will likely fail but let user know)
-    return { name: baseProjectId, slot: 0 };
+    return { name: `${baseProjectId}-0`, slot: 0 };
   } catch {
-    // Docker not available - assume base is available
-    return { name: baseProjectId, slot: 0 };
+    // Docker not available - assume slot 0 is available
+    return { name: `${baseProjectId}-0`, slot: 0 };
   }
 }
 

--- a/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/supabase-ports.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/supabase-ports.ts
@@ -443,13 +443,12 @@ export function getOriginalProjectId(configPath: string, worktreeId?: string): s
  * @returns Worktree-specific project_id
  * @example
  * ```typescript
- * generateWorktreeProjectId('myapp', 0)  // Returns: "myapp"
+ * generateWorktreeProjectId('myapp', 0)  // Returns: "myapp-0"
  * generateWorktreeProjectId('myapp', 1)  // Returns: "myapp-1"
  * generateWorktreeProjectId('myapp', 2)  // Returns: "myapp-2"
  * ```
  */
 export function generateWorktreeProjectId(originalId: string, slot: number): string {
-  if (slot === 0) return originalId;
   return `${originalId}-${slot}`;
 }
 


### PR DESCRIPTION
## Summary

- Fix container naming to always use suffixes (`project-0`, `project-1`, etc.) instead of bare project name for slot 0
- Ensures consistent tmp folder naming (`/tmp/project-0`) whether or not other containers are running
- Makes multi-session debugging easier with predictable naming

## Changes

1. **`generateWorktreeProjectId()`** - Removed special case for slot 0, now always returns `{project}-{slot}`
2. **`findAvailableContainerName()`** - Now starts loop from 0 instead of checking bare name first
3. Updated JSDoc comments to reflect new behavior

## Test plan

- [ ] TypeScript type checking passes
- [ ] All 137 tests pass
- [ ] Fresh session creates `/tmp/{project}-0` and containers `supabase_*_{project}-0`
- [ ] Second concurrent session creates `/tmp/{project}-1` with correct naming

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)