### PR TITLE
fix(nextjs-supabase-ai-sdk-dev): Create supabase/ subdirectory in tmp workdir

### DIFF
--- a/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/supabase-tmp-config.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/supabase-tmp-config.ts
@@ -70,6 +70,8 @@ export function createTmpSupabaseDir(
   ports: SupabasePortSet
 ): TmpSupabaseConfig {
   const tmpDir = getTmpSupabasePath(projectId);
+  // Supabase CLI expects supabase/ subdirectory inside --workdir
+  const tmpSupabaseDir = join(tmpDir, 'supabase');
 
   // Verify original directory exists
   if (!existsSync(originalSupabaseDir)) {
@@ -86,14 +88,16 @@ export function createTmpSupabaseDir(
     rmSync(tmpDir, { recursive: true, force: true });
   }
 
-  // Create tmp directory
-  mkdirSync(tmpDir, { recursive: true });
+  // Create tmp directory with supabase/ subdirectory
+  // Structure: /tmp/{projectId}/supabase/config.toml
+  // This matches what Supabase CLI expects with --workdir flag
+  mkdirSync(tmpSupabaseDir, { recursive: true });
 
-  // Create symlinks for allowed items
-  createSymlinks(tmpDir, originalSupabaseDir);
+  // Create symlinks for allowed items inside supabase/ subdirectory
+  createSymlinks(tmpSupabaseDir, originalSupabaseDir);
 
-  // Copy and update config.toml
-  const tmpConfigPath = join(tmpDir, 'config.toml');
+  // Copy and update config.toml inside supabase/ subdirectory
+  const tmpConfigPath = join(tmpSupabaseDir, 'config.toml');
   copyAndUpdateConfig(originalConfigPath, tmpConfigPath, projectId, ports);
 
   return {


### PR DESCRIPTION
## Summary

This is a follow-up fix for #278 and #279. The previous fix addressed consistent naming (`-0`, `-1`, `-2`), but missed a critical issue:

**Root cause:** Supabase CLI with `--workdir` flag expects the directory structure:
```
/tmp/{projectId}/supabase/config.toml
```

We were incorrectly creating:
```
/tmp/{projectId}/config.toml
```

This caused the CLI to fall back to default ports (54322) instead of using the custom ports specified in config.toml, resulting in port conflicts when running multiple sessions.

## Changes

- Modified `createTmpSupabaseDir()` to create a `supabase/` subdirectory inside the tmp workdir
- Symlinks and config.toml are now placed in the correct location

## Test plan

- [ ] TypeScript type checking passes
- [ ] All 137 tests pass
- [ ] Fresh session creates `/tmp/{project}-0/supabase/config.toml`
- [ ] Second concurrent session uses different ports without conflicts

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)