### PR TITLE
fix(github-orchestration): Require new documentation when commits made after comment

### DIFF
--- a/plugins/github-orchestration/hooks/commit-session-await-ci-status.ts
+++ b/plugins/github-orchestration/hooks/commit-session-await-ci-status.ts
@@ -1202,12 +1202,28 @@ ${checksTable}
 
     // No PR - check if comment posted for this session
     // First check session state flag (survives across stop attempts)
+    // BUT also check if new commits were made since the comment was posted
     if (sessionState.commentPosted) {
-      await logger.logOutput({ debug: 'Comment previously posted - allowing stop' });
-      return {
-        decision: 'approve',
-        systemMessage: '✅ Session progress already documented'
-      };
+      const currentHeadSha = await getCurrentHeadSha(repoRoot);
+
+      // If we have a commentPostedAtSha, check if new commits were made since then
+      if (sessionState.commentPostedAtSha &&
+          currentHeadSha !== sessionState.commentPostedAtSha) {
+        // New commits since comment - reset flag and require new documentation
+        await logger.logOutput({ debug: 'New commits since comment - resetting commentPosted flag' });
+        await updateSessionStopState(input.session_id, {
+          commentPosted: false,
+          commentPostedAtSha: undefined,
+        }, repoRoot);
+        // Fall through to blocking logic below
+      } else {
+        // Same commit or no tracking - allow stop
+        await logger.logOutput({ debug: 'Comment previously posted - allowing stop' });
+        return {
+          decision: 'approve',
+          systemMessage: '✅ Session progress already documented'
+        };
+      }
     }
 
     // Try to discover linked issue
@@ -1218,9 +1234,11 @@ ${checksTable}
 
     // Check GitHub for comment if we have an issue number
     if (issueNumber && await hasCommentForSession(issueNumber, input.session_id, repoRoot)) {
-      // Comment posted - update state flag and reset block count
+      // Comment posted - update state flag, save SHA, and reset block count
+      const currentSha = await getCurrentHeadSha(repoRoot);
       await updateSessionStopState(input.session_id, {
         commentPosted: true,
+        commentPostedAtSha: currentSha || undefined,  // Track when comment was posted
         blockCount: 0,
       }, repoRoot);
 

--- a/plugins/github-orchestration/shared/hooks/utils/session-state.ts
+++ b/plugins/github-orchestration/shared/hooks/utils/session-state.ts
@@ -65,6 +65,11 @@ export interface SessionStopState {
    * When current HEAD matches this, we've already seen these commits
    */
   lastSeenCommitSha?: string;
+  /**
+   * Commit SHA when comment was posted - used to detect new commits after comment
+   * If current HEAD differs from this, new commits need documentation
+   */
+  commentPostedAtSha?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fixes the stop hook to detect when new commits are made after a comment was posted
- Previously, once `commentPosted: true` was set, the stop hook would always approve, even if new commits were made
- Now tracks `commentPostedAtSha` to compare against current HEAD

## Changes
- **session-state.ts**: Added `commentPostedAtSha?: string` field to `SessionStopState` interface
- **commit-session-await-ci-status.ts**: 
  - Check for new commits when `commentPosted: true` - reset flag if HEAD differs from `commentPostedAtSha`
  - Save `commentPostedAtSha` when detecting existing comments on GitHub

## Test plan
- [ ] Start session, make commit, post comment to linked issue
- [ ] Verify stop hook approves (comment documented)
- [ ] Make another commit
- [ ] Attempt to stop - should block and request new documentation
- [ ] Post new comment or update existing comment
- [ ] Verify stop hook approves again

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)