### PR TITLE
feat: Convert non-HTTP MCPs to nodes-md proxy

### DIFF
--- a/plugins/nextjs-supabase-ai-sdk-dev/.claude-plugin/plugin.json
+++ b/plugins/nextjs-supabase-ai-sdk-dev/.claude-plugin/plugin.json
@@ -9,9 +9,9 @@
   "license": "MIT",
   "keywords": ["nextjs", "supabase", "ai-sdk", "development"],
   "mcpServers": {
-    "next-devtools": {
+    "nodes": {
       "command": "npx",
-      "args": ["-y", "next-devtools-mcp@latest"]
+      "args": ["-y", "nodes-md@latest"]
     },
     "ai-elements": {
       "command": "npx",
@@ -24,10 +24,6 @@
     "vercel": {
       "command": "npx",
       "args": ["-y", "mcp-remote@latest", "https://mcp.vercel.com"]
-    },
-    "shadcn": {
-      "command": "npx",
-      "args": ["shadcn@latest", "mcp"]
     }
   }
 }

--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/hooks.json
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/hooks.json
@@ -14,6 +14,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/setup-nodes-config.ts",
+            "description": "Creates .nodes/.mcp.nodes.json config for the nodes-md MCP proxy"
+          },
+          {
+            "type": "command",
             "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/install-vercel.ts",
             "description": "Installs Vercel CLI on remote, warns if missing on local"
           },

--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/setup-nodes-config.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/setup-nodes-config.ts
@@ -1,0 +1,166 @@
+/**
+ * Nodes MCP Config Setup Hook
+ * SessionStart hook that creates .nodes/.mcp.nodes.json config for the nodes-md proxy.
+ * Merges with existing config if present (for multi-plugin support).
+ * @module setup-nodes-config
+ */
+
+import type { SessionStartInput, SessionStartHookOutput } from '../shared/types/types.js';
+import { createDebugLogger } from '../shared/hooks/utils/debug.js';
+import { runHook } from '../shared/hooks/utils/io.js';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Nodes MCP server configuration
+ */
+interface NodesServer {
+  transport: 'stdio' | 'sse';
+  command?: string;
+  args?: string[];
+  url?: string;
+}
+
+/**
+ * Nodes MCP config file structure
+ */
+interface NodesConfig {
+  servers: Record<string, NodesServer>;
+}
+
+/**
+ * Servers this plugin contributes to the nodes config
+ * Only local/stdio servers go through nodes - HTTP servers stay as mcp-remote
+ */
+const PLUGIN_SERVERS: Record<string, NodesServer> = {
+  'next-devtools': {
+    transport: 'stdio',
+    command: 'npx',
+    args: ['-y', 'next-devtools-mcp@latest'],
+  },
+  shadcn: {
+    transport: 'stdio',
+    command: 'npx',
+    args: ['shadcn@latest', 'mcp'],
+  },
+};
+
+/**
+ * Load existing nodes config or return empty config
+ */
+function loadNodesConfig(configPath: string): NodesConfig {
+  if (existsSync(configPath)) {
+    try {
+      const content = readFileSync(configPath, 'utf-8');
+      return JSON.parse(content) as NodesConfig;
+    } catch {
+      // Invalid JSON, start fresh
+      return { servers: {} };
+    }
+  }
+  return { servers: {} };
+}
+
+/**
+ * Add .nodes/ to .gitignore if not already present
+ */
+function addToGitignore(cwd: string): boolean {
+  const gitignorePath = join(cwd, '.gitignore');
+
+  if (existsSync(gitignorePath)) {
+    const content = readFileSync(gitignorePath, 'utf-8');
+    if (content.includes('.nodes/') || content.includes('.nodes')) {
+      return false; // Already present
+    }
+    appendFileSync(gitignorePath, '\n# nodes-md MCP config\n.nodes/\n');
+    return true;
+  } else {
+    writeFileSync(gitignorePath, '# nodes-md MCP config\n.nodes/\n');
+    return true;
+  }
+}
+
+/**
+ * SessionStart hook handler
+ * Creates .nodes/.mcp.nodes.json with this plugin's servers
+ */
+async function handler(input: SessionStartInput): Promise<SessionStartHookOutput> {
+  const logger = createDebugLogger(input.cwd, 'setup-nodes-config', true);
+  const messages: string[] = [];
+
+  try {
+    await logger.logInput({
+      source: input.source,
+      session_id: input.session_id,
+    });
+
+    const nodesDir = join(input.cwd, '.nodes');
+    const configPath = join(nodesDir, '.mcp.nodes.json');
+
+    // Create .nodes directory if needed
+    if (!existsSync(nodesDir)) {
+      mkdirSync(nodesDir, { recursive: true });
+      messages.push('Created .nodes/ directory');
+    }
+
+    // Load existing config and merge
+    const config = loadNodesConfig(configPath);
+    const existingServers = Object.keys(config.servers);
+    const newServers: string[] = [];
+
+    // Merge plugin servers (this plugin's servers take precedence)
+    for (const [name, server] of Object.entries(PLUGIN_SERVERS)) {
+      if (!config.servers[name]) {
+        newServers.push(name);
+      }
+      config.servers[name] = server;
+    }
+
+    // Write updated config
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+
+    if (newServers.length > 0) {
+      messages.push(`Added servers to .nodes config: ${newServers.join(', ')}`);
+    } else {
+      messages.push('Nodes config up to date');
+    }
+
+    if (existingServers.length > 0) {
+      const otherServers = existingServers.filter((s) => !PLUGIN_SERVERS[s]);
+      if (otherServers.length > 0) {
+        messages.push(`Other servers in config: ${otherServers.join(', ')}`);
+      }
+    }
+
+    // Add to .gitignore
+    if (addToGitignore(input.cwd)) {
+      messages.push('Added .nodes/ to .gitignore');
+    }
+
+    const finalMessage = messages.join('\n');
+
+    await logger.logOutput({
+      success: true,
+      message: finalMessage,
+    });
+
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'SessionStart',
+        additionalContext: finalMessage,
+      },
+    };
+  } catch (error) {
+    await logger.logError(error as Error);
+
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'SessionStart',
+        additionalContext: `Nodes config setup error: ${error}`,
+      },
+    };
+  }
+}
+
+export { handler };
+runHook(handler);

--- a/plugins/project-context/.claude-plugin/plugin.json
+++ b/plugins/project-context/.claude-plugin/plugin.json
@@ -17,9 +17,9 @@
     "claude-code"
   ],
   "mcpServers": {
-    "context7": {
+    "nodes": {
       "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp@latest"]
+      "args": ["-y", "nodes-md@latest"]
     }
   }
 }

--- a/plugins/project-context/hooks/hooks.json
+++ b/plugins/project-context/hooks/hooks.json
@@ -10,6 +10,17 @@
   ],
   "description": "Enhanced context discovery and maintenance for Claude Code",
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/setup-nodes-config.ts",
+            "description": "Creates .nodes/.mcp.nodes.json config for the nodes-md MCP proxy"
+          }
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "hooks": [

--- a/plugins/project-context/hooks/setup-nodes-config.ts
+++ b/plugins/project-context/hooks/setup-nodes-config.ts
@@ -1,0 +1,160 @@
+/**
+ * Nodes MCP Config Setup Hook
+ * SessionStart hook that creates .nodes/.mcp.nodes.json config for the nodes-md proxy.
+ * Merges with existing config if present (for multi-plugin support).
+ * @module setup-nodes-config
+ */
+
+import type { SessionStartInput, SessionStartHookOutput } from '../shared/types/types.js';
+import { createDebugLogger } from '../shared/hooks/utils/debug.js';
+import { runHook } from '../shared/hooks/utils/io.js';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, appendFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Nodes MCP server configuration
+ */
+interface NodesServer {
+  transport: 'stdio' | 'sse';
+  command?: string;
+  args?: string[];
+  url?: string;
+}
+
+/**
+ * Nodes MCP config file structure
+ */
+interface NodesConfig {
+  servers: Record<string, NodesServer>;
+}
+
+/**
+ * Servers this plugin contributes to the nodes config
+ */
+const PLUGIN_SERVERS: Record<string, NodesServer> = {
+  context7: {
+    transport: 'stdio',
+    command: 'npx',
+    args: ['-y', '@upstash/context7-mcp@latest'],
+  },
+};
+
+/**
+ * Load existing nodes config or return empty config
+ */
+function loadNodesConfig(configPath: string): NodesConfig {
+  if (existsSync(configPath)) {
+    try {
+      const content = readFileSync(configPath, 'utf-8');
+      return JSON.parse(content) as NodesConfig;
+    } catch {
+      // Invalid JSON, start fresh
+      return { servers: {} };
+    }
+  }
+  return { servers: {} };
+}
+
+/**
+ * Add .nodes/ to .gitignore if not already present
+ */
+function addToGitignore(cwd: string): boolean {
+  const gitignorePath = join(cwd, '.gitignore');
+
+  if (existsSync(gitignorePath)) {
+    const content = readFileSync(gitignorePath, 'utf-8');
+    if (content.includes('.nodes/') || content.includes('.nodes')) {
+      return false; // Already present
+    }
+    appendFileSync(gitignorePath, '\n# nodes-md MCP config\n.nodes/\n');
+    return true;
+  } else {
+    writeFileSync(gitignorePath, '# nodes-md MCP config\n.nodes/\n');
+    return true;
+  }
+}
+
+/**
+ * SessionStart hook handler
+ * Creates .nodes/.mcp.nodes.json with this plugin's servers
+ */
+async function handler(input: SessionStartInput): Promise<SessionStartHookOutput> {
+  const logger = createDebugLogger(input.cwd, 'setup-nodes-config', true);
+  const messages: string[] = [];
+
+  try {
+    await logger.logInput({
+      source: input.source,
+      session_id: input.session_id,
+    });
+
+    const nodesDir = join(input.cwd, '.nodes');
+    const configPath = join(nodesDir, '.mcp.nodes.json');
+
+    // Create .nodes directory if needed
+    if (!existsSync(nodesDir)) {
+      mkdirSync(nodesDir, { recursive: true });
+      messages.push('Created .nodes/ directory');
+    }
+
+    // Load existing config and merge
+    const config = loadNodesConfig(configPath);
+    const existingServers = Object.keys(config.servers);
+    const newServers: string[] = [];
+
+    // Merge plugin servers (this plugin's servers take precedence)
+    for (const [name, server] of Object.entries(PLUGIN_SERVERS)) {
+      if (!config.servers[name]) {
+        newServers.push(name);
+      }
+      config.servers[name] = server;
+    }
+
+    // Write updated config
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
+
+    if (newServers.length > 0) {
+      messages.push(`Added servers to .nodes config: ${newServers.join(', ')}`);
+    } else {
+      messages.push('Nodes config up to date');
+    }
+
+    if (existingServers.length > 0) {
+      const otherServers = existingServers.filter((s) => !PLUGIN_SERVERS[s]);
+      if (otherServers.length > 0) {
+        messages.push(`Other servers in config: ${otherServers.join(', ')}`);
+      }
+    }
+
+    // Add to .gitignore
+    if (addToGitignore(input.cwd)) {
+      messages.push('Added .nodes/ to .gitignore');
+    }
+
+    const finalMessage = messages.join('\n');
+
+    await logger.logOutput({
+      success: true,
+      message: finalMessage,
+    });
+
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'SessionStart',
+        additionalContext: finalMessage,
+      },
+    };
+  } catch (error) {
+    await logger.logError(error as Error);
+
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'SessionStart',
+        additionalContext: `Nodes config setup error: ${error}`,
+      },
+    };
+  }
+}
+
+export { handler };
+runHook(handler);


### PR DESCRIPTION
## Summary

- Convert local/stdio MCP servers to use `nodes-md` npm package as unified proxy
- Add SessionStart hooks to create `.nodes/.mcp.nodes.json` config files
- HTTP servers (ai-elements, supabase, vercel) remain as direct mcp-remote entries

## Changes

### project-context plugin
- New `setup-nodes-config.ts` hook creates config for `context7` server
- Replaced `context7` MCP with single `nodes` entry in plugin.json

### nextjs-supabase-ai-sdk-dev plugin
- New `setup-nodes-config.ts` hook creates config for `next-devtools` and `shadcn` servers
- Replaced `next-devtools` and `shadcn` with single `nodes` entry
- Kept HTTP servers (ai-elements, supabase, vercel) as direct mcp-remote

## How It Works

1. SessionStart hooks generate `.nodes/.mcp.nodes.json` with server configs
2. `nodes-md` reads config and proxies to configured servers
3. Multi-plugin support: configs merge when multiple plugins installed
4. `.nodes/` directory auto-added to `.gitignore`

## Test plan

- [x] TypeScript checks pass
- [x] All tests pass (137/137)
- [ ] Install updated plugins in fresh session
- [ ] Verify `.nodes/.mcp.nodes.json` created on session start
- [ ] Test tool access via nodes proxy

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)