### PR TITLE
fix(nextjs-supabase-ai-sdk-dev): Check port availability for configured ports

### DIFF
--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/install-start-supabase-next.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/install-start-supabase-next.ts
@@ -17,7 +17,7 @@ import { detectPackageManager } from '../shared/hooks/utils/package-manager.js';
 import { isPortAvailable, findAvailablePort, killProcessOnPort, findAvailablePortAt10Increments } from '../shared/hooks/utils/port.js';
 import { getWranglerDevPort } from '../shared/hooks/utils/toml.js';
 import { findViteConfigPort } from '../shared/hooks/utils/vite-config.js';
-import { distributeEnvVars, mergeWorkspaceEnvVars, validateEnvVars, detectSupabaseUsage, hasSupabaseInMonorepo, generateAppUrls, detectWorkspaceFramework, type DevServerPorts, type WorkspaceInfo } from '../shared/hooks/utils/env-sync.js';
+import { distributeEnvVars, mergeWorkspaceEnvVars, validateEnvVars, detectSupabaseUsage, hasSupabaseInMonorepo, generateAppUrls, detectWorkspaceFramework, resolveWorkspacePorts, type DevServerPorts, type WorkspaceInfo } from '../shared/hooks/utils/env-sync.js';
 import { detectWorktree, type WorktreeInfo } from '../shared/hooks/utils/worktree.js';
 import {
   PORT_INCREMENT,
@@ -343,6 +343,10 @@ async function distributeAllEnvVars(
 
       workspaceInfos.push({ path: ws, name, framework, configuredPort });
     }
+
+    // Resolve ports (check availability and find alternatives at +10 increments)
+    // This ensures multiple Claude sessions can run in parallel without port conflicts
+    await resolveWorkspacePorts(workspaceInfos, devServerPorts);
 
     appUrlsByWorkspace = generateAppUrls(workspaceInfos, devServerPorts);
   }

--- a/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/env-sync.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/env-sync.ts
@@ -15,6 +15,7 @@
 
 import { existsSync, readFileSync, writeFileSync, readdirSync } from 'fs';
 import { join } from 'path';
+import { isPortAvailable } from './port.js';
 
 /**
  * Workspace framework type for environment variable prefixing
@@ -608,6 +609,97 @@ export interface WorkspaceInfo {
   framework: WorkspaceFramework;
   /** Port configured in package.json dev script (--port flag), or null if not configured */
   configuredPort: number | null;
+  /** Port after availability check - use this instead of configuredPort for URL generation */
+  resolvedPort?: number;
+}
+
+/**
+ * Resolve ports for workspaces, checking availability and finding alternatives
+ *
+ * For each workspace:
+ * 1. Try configuredPort (from package.json) if set
+ * 2. Fall back to base port from DevServerPorts
+ * 3. If port is unavailable, find next available at +10 increments
+ *
+ * This ensures multiple Claude sessions can run in parallel without port conflicts.
+ *
+ * @param workspaces - Array of workspace info objects (mutated with resolvedPort)
+ * @param basePorts - Base ports for each framework type
+ * @returns Promise resolving to the same array with resolvedPort filled in
+ *
+ * @example
+ * ```typescript
+ * import { resolveWorkspacePorts } from './env-sync.js';
+ *
+ * const workspaces = [
+ *   { path: 'apps/app', name: 'app', framework: 'nextjs', configuredPort: 3100 },
+ *   { path: 'apps/mcp', name: 'mcp', framework: 'cloudflare', configuredPort: 3102 },
+ * ];
+ *
+ * await resolveWorkspacePorts(workspaces, { nextjs: 3000, vite: 5173, cloudflare: 8787 });
+ * // If 3100 is in use: workspaces[0].resolvedPort = 3110
+ * // If 3102 is in use: workspaces[1].resolvedPort = 3112
+ * ```
+ */
+export async function resolveWorkspacePorts(
+  workspaces: WorkspaceInfo[],
+  basePorts: DevServerPorts
+): Promise<WorkspaceInfo[]> {
+  // Track ports we've already claimed in this resolution to avoid duplicates
+  const claimedPorts = new Set<number>();
+
+  // Only process workspaces with dev servers
+  const appWorkspaces = workspaces.filter(
+    (ws) =>
+      ws.framework === 'nextjs' || ws.framework === 'vite' || ws.framework === 'cloudflare'
+  );
+
+  for (const ws of appWorkspaces) {
+    // Determine the preferred port (configured or framework default)
+    const preferredPort = ws.configuredPort ?? basePorts[ws.framework as keyof DevServerPorts];
+
+    // Check if preferred port is available and not already claimed
+    const available = await isPortAvailable(preferredPort);
+    if (available && !claimedPorts.has(preferredPort)) {
+      ws.resolvedPort = preferredPort;
+      claimedPorts.add(preferredPort);
+      continue;
+    }
+
+    // Port not available, find next at +10 increments
+    const resolvedPort = await findAvailablePortExcluding(preferredPort, claimedPorts, 25);
+
+    if (resolvedPort !== null) {
+      ws.resolvedPort = resolvedPort;
+      claimedPorts.add(resolvedPort);
+    } else {
+      // Fallback: use preferred port anyway (will likely fail at runtime)
+      ws.resolvedPort = preferredPort;
+    }
+  }
+
+  return workspaces;
+}
+
+/**
+ * Find available port at +10 increments, excluding already claimed ports
+ */
+async function findAvailablePortExcluding(
+  basePort: number,
+  excludePorts: Set<number>,
+  maxSlots: number = 25
+): Promise<number | null> {
+  for (let slot = 0; slot < maxSlots; slot++) {
+    const port = basePort + slot * 10;
+    if (excludePorts.has(port)) {
+      continue;
+    }
+    const available = await isPortAvailable(port);
+    if (available) {
+      return port;
+    }
+  }
+  return null;
 }
 
 /**
@@ -675,12 +767,15 @@ export function generateAppUrls(
   };
 
   // Assign ports to each app workspace
-  // Priority: configuredPort > base port + offset
+  // Priority: resolvedPort (after availability check) > configuredPort > base port + offset
   for (const ws of appWorkspaces) {
     let port: number;
 
-    if (ws.configuredPort !== null) {
-      // Use the port configured in package.json dev script
+    if (ws.resolvedPort !== undefined) {
+      // Use pre-resolved port (already checked for availability)
+      port = ws.resolvedPort;
+    } else if (ws.configuredPort !== null) {
+      // Fallback to configured port (legacy behavior, no availability check)
       port = ws.configuredPort;
     } else {
       // Fall back to base port + offset for workspaces without configured port


### PR DESCRIPTION
## Summary

- Fixes port conflicts when multiple Claude sessions run in parallel
- Adds `resolvedPort` field to track available ports after checking
- Uses +10 increment to find alternative ports when configured port is taken

## Problem

When running multiple Claude sessions in different worktrees of the same repo, all sessions would try to use the same ports (e.g., 3100, 3101, 3102) because `generateAppUrls()` used configured ports directly without checking availability.

## Solution

1. Added `resolvedPort` field to `WorkspaceInfo` interface
2. Created `resolveWorkspacePorts()` function that:
   - Checks if configured port is available
   - If not, finds next available port at +10 increments
3. Updated `generateAppUrls()` to use `resolvedPort` when available
4. Called `resolveWorkspacePorts()` before URL generation

## Test plan

- [ ] Start first Claude session in nodes-md - verify ports 3100, 3101, 3102
- [ ] Start second Claude session in another worktree
- [ ] Verify second session gets ports 3110, 3111, 3112
- [ ] Verify env vars point to correct offset ports

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)