### PR TITLE
fix(refresh-plugins): Include constellos-local plugins in refresh

### DIFF
--- a/.claude/hooks/refresh-plugins.sh
+++ b/.claude/hooks/refresh-plugins.sh
@@ -6,8 +6,8 @@ SETTINGS_FILE=".claude/settings.json"
 
 echo "🔄 Refreshing constellos plugins..."
 
-# Extract enabled constellos plugins from settings.json
-PLUGINS=$(jq -r '.enabledPlugins | keys[] | select(endswith("@constellos"))' "$SETTINGS_FILE")
+# Extract enabled constellos and constellos-local plugins from settings.json
+PLUGINS=$(jq -r '.enabledPlugins | keys[] | select(endswith("@constellos") or endswith("@constellos-local"))' "$SETTINGS_FILE")
 
 if [ -z "$PLUGINS" ]; then
   echo "⚠️  No constellos plugins found in settings.json"
@@ -20,9 +20,11 @@ while IFS= read -r plugin; do
   claude plugin uninstall --scope project "$plugin" 2>/dev/null || true
 done <<< "$PLUGINS"
 
-# Clear entire constellos cache directory
-echo "  - Clearing constellos cache..."
+# Clear constellos and constellos-local cache directories
+echo "  - Clearing constellos caches..."
 rm -rf ~/.claude/plugins/cache/constellos/* 2>/dev/null || true
+rm -rf ~/.claude/plugins/cache/constellos-local 2>/dev/null || true
+rm -rf ~/.claude/plugins/cache/.constellos-local-caches/* 2>/dev/null || true
 
 # Reinstall all enabled constellos plugins
 while IFS= read -r plugin; do


### PR DESCRIPTION
## Summary
The `refresh-plugins.sh` SessionEnd hook was only refreshing `@constellos` plugins, not `@constellos-local` plugins. This caused stale plugin cache issues when developing plugins locally in worktrees.

## Changes
- Updated jq filter to match both `@constellos` and `@constellos-local`
- Clear both `constellos` and `constellos-local` cache directories

## Root cause
When using `constellos-local` marketplace source (directory-based), Claude Code copies files into the cache rather than symlinking. Plugin changes made after the initial install weren't being picked up because the refresh script only cleared `@constellos` caches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)