### PR TITLE
fix: Add self-referential URLs, Elysia support, and per-app port variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dist/
 PLAN.md
 plugins/**/hooks/.claude/
 .worktrees/
+
+# nodes-md MCP config
+.nodes/

--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/install-start-supabase-next.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/install-start-supabase-next.ts
@@ -98,6 +98,14 @@ function isRemoteEnvironment(): boolean {
 }
 
 /**
+ * Check if Docker is installed (not just running)
+ */
+async function isDockerInstalled(): Promise<boolean> {
+  const result = await execCommand('which docker', { timeout: 5000 });
+  return result.success && result.stdout.length > 0;
+}
+
+/**
  * Get Supabase CLI version
  */
 async function getSupabaseVersion(): Promise<string | null> {
@@ -1656,27 +1664,39 @@ async function handler(input: SessionStartInput): Promise<SessionStartHookOutput
     }
 
     // ========== Step 3: Check/Start Docker ==========
-    let dockerRunning = await isDockerRunning();
+    let dockerRunning = false;
+    let skipSupabase = false;
 
-    if (!dockerRunning) {
+    // Check if Docker is installed first
+    const dockerInstalled = await isDockerInstalled();
+    if (!dockerInstalled) {
       messages.push('');
-      messages.push('Docker not running, attempting to start...');
-      const started = await startDocker();
-
-      if (started) {
-        messages.push('Waiting for Docker to be ready...');
-        dockerRunning = await waitForDocker(30000);
-      }
+      messages.push('ℹ️ Docker not installed - skipping Supabase setup');
+      messages.push('  Install Docker: https://docker.com/products/docker-desktop');
+      skipSupabase = true;
+    } else {
+      dockerRunning = await isDockerRunning();
 
       if (!dockerRunning) {
-        messages.push('⚠️ Could not start Docker');
-        messages.push('  Please start Docker Desktop manually');
-        // Continue but note that Supabase won't start
+        messages.push('');
+        messages.push('Docker not running, attempting to start...');
+        const started = await startDocker();
+
+        if (started) {
+          messages.push('Waiting for Docker to be ready...');
+          dockerRunning = await waitForDocker(30000);
+        }
+
+        if (!dockerRunning) {
+          messages.push('⚠️ Could not start Docker');
+          messages.push('  Please start Docker Desktop manually');
+          skipSupabase = true;
+        } else {
+          messages.push('✓ Docker started');
+        }
       } else {
-        messages.push('✓ Docker started');
+        messages.push('✓ Docker running');
       }
-    } else {
-      messages.push('✓ Docker running');
     }
 
     // ========== Step 3.5: Clean up orphaned sessions ==========
@@ -1693,7 +1713,7 @@ async function handler(input: SessionStartInput): Promise<SessionStartHookOutput
     // Track tmp config directory for supabase status commands
     let supabaseTmpDir: string | undefined;
 
-    if (dockerRunning) {
+    if (dockerRunning && !skipSupabase) {
       if (instanceConfig.needsNewInstance) {
         // Start new Supabase instance (possibly with custom ports for worktree)
         messages.push('');
@@ -2005,18 +2025,59 @@ async function handler(input: SessionStartInput): Promise<SessionStartHookOutput
       if (projectType === 'turborepo') {
         const workspaces = detectTurborepoWorkspaces(input.cwd);
         if (workspaces && workspaces.length > 0) {
-          // For Turborepo: set PORT env vars for each workspace type
-          for (const ws of workspaces) {
-            const wsPath = join(input.cwd, ws);
-            const wsType = detectProjectType(wsPath);
-            if (wsType === 'nextjs') {
-              devServerEnvVars.PORT = String(availablePorts.nextjs);
-            } else if (wsType === 'vite') {
-              devServerEnvVars.VITE_PORT = String(availablePorts.vite);
-            } else if (wsType === 'cloudflare') {
-              devServerEnvVars.WRANGLER_DEV_PORT = String(availablePorts.cloudflare);
+          // Get workspace port info for per-app PORT variables
+          const workspacePorts = await detectWorkspacePorts(input.cwd, workspaces);
+
+          // Track used ports per framework to handle multiple apps of same type
+          const usedPortsByType: Record<string, number[]> = {
+            nextjs: [],
+            vite: [],
+            cloudflare: [],
+            elysia: [],
+          };
+
+          // For Turborepo: set PORT_{APP_NAME} env var for each app
+          for (const wp of workspacePorts) {
+            const wsName = basename(wp.workspace).toUpperCase().replace(/-/g, '_');
+
+            // Calculate port: configured > base + offset
+            let port: number;
+            if (wp.configuredPort !== null) {
+              port = wp.configuredPort;
+              // Apply worktree offset to configured ports
+              if (worktreeSlot > 0) {
+                port += worktreeSlot * PORT_INCREMENT;
+              }
+            } else {
+              // Use base port + offset for this framework type
+              const usedPorts = usedPortsByType[wp.projectType] || [];
+              const basePort = wp.defaultPort || availablePorts.nextjs;
+              port = basePort + (usedPorts.length * 10);
+              // Apply worktree offset
+              if (worktreeSlot > 0) {
+                port += worktreeSlot * PORT_INCREMENT;
+              }
+            }
+
+            // Track used ports
+            if (usedPortsByType[wp.projectType]) {
+              usedPortsByType[wp.projectType].push(port);
+            }
+
+            // Set per-app PORT variable
+            if (wp.projectType === 'nextjs' || wp.projectType === 'elysia') {
+              devServerEnvVars[`PORT_${wsName}`] = String(port);
+            } else if (wp.projectType === 'vite') {
+              devServerEnvVars[`VITE_PORT_${wsName}`] = String(port);
+            } else if (wp.projectType === 'cloudflare') {
+              devServerEnvVars[`WRANGLER_PORT_${wsName}`] = String(port);
             }
           }
+
+          // Also set legacy framework-level PORT for backwards compatibility
+          devServerEnvVars.PORT = String(availablePorts.nextjs + (worktreeSlot > 0 ? worktreeSlot * PORT_INCREMENT : 0));
+          devServerEnvVars.VITE_PORT = String(availablePorts.vite + (worktreeSlot > 0 ? worktreeSlot * PORT_INCREMENT : 0));
+          devServerEnvVars.WRANGLER_DEV_PORT = String(availablePorts.cloudflare + (worktreeSlot > 0 ? worktreeSlot * PORT_INCREMENT : 0));
         }
       } else {
         // For single-project: apply port based on project type

--- a/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/env-sync.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/shared/hooks/utils/env-sync.ts
@@ -20,7 +20,7 @@ import { isPortAvailable } from './port.js';
 /**
  * Workspace framework type for environment variable prefixing
  */
-export type WorkspaceFramework = 'nextjs' | 'vite' | 'cloudflare' | 'unknown';
+export type WorkspaceFramework = 'nextjs' | 'vite' | 'cloudflare' | 'elysia' | 'unknown';
 
 /**
  * Detect if a workspace uses Supabase by checking dependencies
@@ -165,6 +165,11 @@ export function detectWorkspaceFramework(workspacePath: string): WorkspaceFramew
       if ('wrangler' in allDeps || '@cloudflare/workers-types' in allDeps) {
         return 'cloudflare';
       }
+
+      // Check for Elysia dependency (Bun framework)
+      if ('elysia' in allDeps) {
+        return 'elysia';
+      }
     } catch {
       // Ignore parse errors
     }
@@ -185,6 +190,8 @@ export function getPublicEnvPrefix(framework: WorkspaceFramework): string {
       return 'NEXT_PUBLIC_';
     case 'vite':
       return 'VITE_';
+    case 'elysia':
+    case 'cloudflare':
     default:
       return '';
   }
@@ -746,7 +753,8 @@ export function generateAppUrls(
   const appWorkspaces = workspaces.filter(ws =>
     ws.framework === 'nextjs' ||
     ws.framework === 'vite' ||
-    ws.framework === 'cloudflare'
+    ws.framework === 'cloudflare' ||
+    ws.framework === 'elysia'
   );
 
   // First, calculate the actual port for each app workspace
@@ -755,6 +763,7 @@ export function generateAppUrls(
     nextjs: ports.nextjs,
     vite: ports.vite,
     cloudflare: ports.cloudflare,
+    elysia: ports.nextjs,  // Elysia uses port 3000 like Next.js
     unknown: ports.nextjs,
   };
 
@@ -763,6 +772,7 @@ export function generateAppUrls(
     nextjs: [],
     vite: [],
     cloudflare: [],
+    elysia: [],
     unknown: [],
   };
 
@@ -795,12 +805,24 @@ export function generateAppUrls(
     const url = `http://localhost:${port}`;
     const vars: Record<string, string> = {};
 
-    // Self-reference URL
+    // Self-reference URL with app-specific naming
+    const nameUpper = ws.name.toUpperCase().replace(/-/g, '_');
+
     if (ws.framework === 'nextjs') {
-      vars['NEXT_PUBLIC_APP_URL'] = url;
+      // Add both app-specific name and generic APP_URL for compatibility
+      vars[`NEXT_PUBLIC_${nameUpper}_URL`] = url;  // e.g., NEXT_PUBLIC_WEB_URL
+      vars['NEXT_PUBLIC_APP_URL'] = url;            // Backwards compatibility
+      vars[`${nameUpper}_URL`] = url;               // Server-side (WEB_URL)
     } else if (ws.framework === 'vite') {
+      vars[`VITE_${nameUpper}_URL`] = url;
       vars['VITE_APP_URL'] = url;
+      vars[`${nameUpper}_URL`] = url;
+    } else if (ws.framework === 'elysia') {
+      vars[`${nameUpper}_URL`] = url;
+      vars['APP_URL'] = url;
     } else {
+      // Cloudflare workers - unprefixed
+      vars[`${nameUpper}_URL`] = url;
       vars['APP_URL'] = url;
     }
 
@@ -814,8 +836,10 @@ export function generateAppUrls(
 
       if (ws.framework === 'nextjs') {
         vars[`NEXT_PUBLIC_${otherNameUpper}_URL`] = otherUrl;
+        vars[`${otherNameUpper}_URL`] = otherUrl;  // Also add unprefixed for server
       } else if (ws.framework === 'vite') {
         vars[`VITE_${otherNameUpper}_URL`] = otherUrl;
+        vars[`${otherNameUpper}_URL`] = otherUrl;
       } else {
         vars[`${otherNameUpper}_URL`] = otherUrl;
       }


### PR DESCRIPTION
## Summary

- **Fix missing self-referential URLs**: Each app now gets its own URL env var (e.g., `NEXT_PUBLIC_WEB_URL` for web app) instead of just generic `NEXT_PUBLIC_APP_URL`
- **Add Elysia framework support**: Added Elysia detection and handling in env-sync.ts
- **Add Docker installed check**: Gracefully skip Supabase setup when Docker isn't installed
- **Implement per-app port variables**: Set `PORT_WEB`, `PORT_API`, etc. for multi-app turborepos

## Changes

### env-sync.ts
- Added `'elysia'` to `WorkspaceFramework` type
- Added Elysia detection in `detectWorkspaceFramework()`
- Updated `getPublicEnvPrefix()` to handle Elysia
- Added Elysia to `generateAppUrls()` filter and port maps
- Fixed self-referential URL naming:
  - Each app gets `NEXT_PUBLIC_{APP_NAME}_URL` (e.g., `NEXT_PUBLIC_WEB_URL`)
  - Added unprefixed versions for server-side (`WEB_URL`, `API_URL`)
  - Kept backwards compatibility with `NEXT_PUBLIC_APP_URL`

### install-start-supabase-next.ts
- Added `isDockerInstalled()` function
- Added Docker installed check with skip logic and helpful message
- Implemented per-app PORT variables (`PORT_WEB`, `VITE_PORT_WEB`, `WRANGLER_PORT_MCP`)
- Properly handles worktree slot offsets for port isolation

## User Action Required

For per-app port variables to work, users need to:

1. Update **package.json dev scripts** in each app:
   ```json
   { "dev": "next dev --port ${PORT_WEB:-3000}" }
   ```

2. Add to **turbo.json** `globalPassThroughEnv`:
   ```json
   { "globalPassThroughEnv": ["PORT_*", "VITE_PORT_*", "WRANGLER_PORT_*"] }
   ```

## Test plan

- [ ] Verify self-referential URLs: `apps/web/.env.local` contains `NEXT_PUBLIC_WEB_URL`
- [ ] Verify cross-app URLs: `apps/web/.env.local` contains `NEXT_PUBLIC_API_URL`
- [ ] Verify Elysia apps get unprefixed `{APP_NAME}_URL` vars
- [ ] Verify Docker not installed shows helpful message and continues
- [ ] Verify per-app PORT vars: `PORT_WEB`, `PORT_API` set in env

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)