### PR TITLE
fix: Auto-update turbo.json globalPassThroughEnv for PORT_* patterns

### DIFF
--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/install-start-supabase-next.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/install-start-supabase-next.ts
@@ -627,6 +627,48 @@ function detectProjectType(cwd: string): ProjectType {
 }
 
 /**
+ * Ensure turbo.json has PORT_* patterns in globalPassThroughEnv
+ * Turborepo filters out env vars not listed in globalPassThroughEnv,
+ * so we need to add PORT_*, VITE_PORT_*, and WRANGLER_PORT_* patterns.
+ * Uses skip-worktree to prevent committing this change.
+ */
+async function ensureTurboEnvPassthrough(cwd: string, messages: string[]): Promise<void> {
+  const turboJsonPath = join(cwd, 'turbo.json');
+  if (!existsSync(turboJsonPath)) {
+    return;
+  }
+
+  try {
+    const content = readFileSync(turboJsonPath, 'utf-8');
+    const turboConfig = JSON.parse(content);
+
+    const requiredPatterns = ['PORT_*', 'VITE_PORT_*', 'WRANGLER_PORT_*'];
+    const existing: string[] = turboConfig.globalPassThroughEnv || [];
+
+    const missing = requiredPatterns.filter(p => !existing.includes(p));
+    if (missing.length === 0) {
+      return; // Already has all required patterns
+    }
+
+    turboConfig.globalPassThroughEnv = [...existing, ...missing];
+    writeFileSync(turboJsonPath, JSON.stringify(turboConfig, null, 2) + '\n');
+
+    // Use skip-worktree to prevent committing this change
+    const skipResult = await execCommand(`git update-index --skip-worktree "${turboJsonPath}"`);
+    if (skipResult.success) {
+      messages.push(`✓ Added ${missing.join(', ')} to turbo.json globalPassThroughEnv`);
+      messages.push(`  git skip-worktree set (changes won't be committed)`);
+    } else {
+      // Rollback if skip-worktree failed
+      writeFileSync(turboJsonPath, content);
+      messages.push(`⚠️ Could not set skip-worktree for turbo.json`);
+    }
+  } catch (error) {
+    messages.push(`⚠️ Could not update turbo.json: ${error}`);
+  }
+}
+
+/**
  * Modified package.json info for cleanup tracking
  */
 interface ModifiedPackageJson {
@@ -2098,11 +2140,16 @@ async function handler(input: SessionStartInput): Promise<SessionStartHookOutput
         }
       }
 
-      // For Turborepo: modify package.json dev scripts to use PORT env vars
+      // For Turborepo: modify turbo.json and package.json for dynamic port assignment
       // This must happen BEFORE starting the dev server
       if (projectType === 'turborepo') {
         const workspacesForPortMod = detectTurborepoWorkspaces(input.cwd);
         if (workspacesForPortMod && workspacesForPortMod.length > 0) {
+          // First, ensure turbo.json has PORT_* patterns in globalPassThroughEnv
+          // This is required for Turborepo to pass PORT_APP, PORT_WEB etc. to workspaces
+          await ensureTurboEnvPassthrough(input.cwd, messages);
+
+          // Then modify package.json dev scripts to use PORT env vars
           const modifiedPkgs = await modifyPackageJsonForDynamicPorts(
             input.cwd,
             workspacesForPortMod,


### PR DESCRIPTION
## Summary

Fixes a bug where PORT_APP and PORT_WEB env vars were being filtered out by Turborepo before reaching Next.js dev scripts.

**Root cause:** `turbo.json` was missing `PORT_*` patterns in `globalPassThroughEnv`. Turborepo filters out environment variables not listed there, so even though the hook set `PORT_APP=3110`, Turborepo filtered it out, causing the script to fall back to the default port (which was already in use).

**Evidence from logs:**
```
@nodes-md/app:dev: > next dev --port ${PORT_APP:-3100}
...
Error: listen EADDRINUSE: address already in use :::3100
```

## Changes

- Adds `ensureTurboEnvPassthrough()` function that:
  - Adds `PORT_*`, `VITE_PORT_*`, `WRANGLER_PORT_*` patterns to turbo.json
  - Uses `git skip-worktree` to prevent committing the change
  - Runs before `modifyPackageJsonForDynamicPorts()`

## Test plan

- [ ] Start a new Claude session in a nodes-md worktree
- [ ] Verify turbo.json is modified to include `PORT_*` patterns
- [ ] Verify `git status` shows no changes (skip-worktree working)
- [ ] Verify dev servers start on offset ports (3110/3111 for slot 1)

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)