### PR TITLE
fix: Update regex to extract port from env var syntax

### DIFF
--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/install-start-supabase-next.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/install-start-supabase-next.ts
@@ -768,7 +768,8 @@ function extractPortFromDevScript(packageJsonPath: string): number | null {
     }
 
     // Match --port XXXX or -p XXXX patterns
-    const portMatch = devScript.match(/(?:--port|-p)\s+(\d+)/);
+    // Also handles env var syntax: --port ${PORT_APP:-3100} -> extracts 3100
+    const portMatch = devScript.match(/(?:--port|-p)\s+(?:\$\{[^:]+:-)?(\d+)/);
     if (portMatch) {
       return parseInt(portMatch[1], 10);
     }


### PR DESCRIPTION
## Summary

Fixes a bug where `extractPortFromDevScript()` couldn't extract the configured port after `modifyPackageJsonForDynamicPorts()` had already modified the package.json.

**Root cause:** The regex `(?:--port|-p)\s+(\d+)` only matches literal numbers like `3100`, not env var syntax like `${PORT_APP:-3100}`.

**Order of operations causing the bug:**
1. `detectWorkspacePorts()` extracts 3100 from `--port 3100` ✅
2. `modifyPackageJsonForDynamicPorts()` changes to `--port ${PORT_APP:-3100}`
3. `detectWorkspacePorts()` called AGAIN - regex fails, returns null ❌
4. Code falls back to `defaultPort || availablePorts.nextjs` = 3000

**Result:** Apps start on 3000/3010 instead of configured 3100/3101.

## Changes

Updated regex from:
```
(?:--port|-p)\s+(\d+)
```

To:
```
(?:--port|-p)\s+(?:\$\{[^:]+:-)?(\d+)
```

This handles both:
- `--port 3100` → captures `3100`
- `--port ${PORT_APP:-3100}` → captures `3100`

## Test plan

- [ ] Start a new session in a nodes-md worktree (slot 0)
- [ ] Verify apps start on configured ports (3100, 3101, 3102)
- [ ] Verify .env.local URLs match actual running ports
- [ ] Test slot 1 uses offset ports (3110, 3111, 3112)

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)