### PR TITLE
feat: Enhanced session stop hook with grouped previews and linked issues

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -92,9 +92,9 @@
     "plugin-dev@claude-code-plugins": true,
     "feature-dev@claude-code-plugins": true,
     "github-orchestration@constellos-local": true,
-    "project-context@constellos-local": true,
+    "nextjs-supabase-ai-sdk-dev@constellos": true,
     "nextjs-supabase-ai-sdk-dev@constellos-local": true,
-    "nextjs-supabase-ai-sdk-dev@constellos": true
+    "project-context@constellos-local": true
   },
   "extraKnownMarketplaces": {
     "constellos-local": {

--- a/plugins/github-orchestration/hooks/await-pr-status.ts
+++ b/plugins/github-orchestration/hooks/await-pr-status.ts
@@ -30,7 +30,9 @@ import {
   awaitCIWithFailFast,
   getLatestCIRun,
   extractPreviewUrls,
+  extractLinkedIssuesFromPR,
 } from '../shared/hooks/utils/ci-status.js';
+import { addPRToState } from '../shared/hooks/utils/github-state.js';
 
 // Local CI functions removed - using shared utilities from ci-status.ts
 
@@ -103,11 +105,29 @@ async function handler(
     // Wait for CI checks with fail-fast behavior
     const ciResult = await awaitCIWithFailFast({ prNumber }, input.cwd);
 
-    // Get latest CI run details
-    const ciRun = await getLatestCIRun(prNumber, input.cwd);
+    // Get latest CI run details, preview URLs, and linked issues in parallel
+    const [ciRun, previewUrls, linkedIssues] = await Promise.all([
+      getLatestCIRun(prNumber, input.cwd),
+      extractPreviewUrls(prNumber, input.cwd),
+      extractLinkedIssuesFromPR(prNumber, input.cwd),
+    ]);
 
-    // Get Vercel preview URLs
-    const previewUrls = await extractPreviewUrls(prNumber, input.cwd);
+    // Extract PR URL from original command output
+    const prUrlMatch = resultText.match(/https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+/);
+    const prUrl = prUrlMatch ? prUrlMatch[0] : `https://github.com/unknown/unknown/pull/${prNumber}`;
+
+    // Track PR in github.json
+    await addPRToState(
+      input.session_id,
+      {
+        number: prNumber,
+        url: prUrl,
+        title: '', // Title not available from gh pr create output
+        createdAt: new Date().toISOString(),
+        linkedIssues,
+      },
+      input.cwd
+    );
 
     // Save full CI output to log file if there are checks
     let logPath: string | undefined;

--- a/plugins/github-orchestration/hooks/commit-session-await-ci-status.ts
+++ b/plugins/github-orchestration/hooks/commit-session-await-ci-status.ts
@@ -52,8 +52,11 @@ import {
 import {
   awaitCIWithFailFast,
   getLatestCIRun as getCIRunDetails,
-  extractPreviewUrls,
+  extractAllPreviews,
+  extractLinkedIssuesFromPR,
+  type GroupedPreviewUrls,
 } from '../shared/hooks/utils/ci-status.js';
+import { addPRToState } from '../shared/hooks/utils/github-state.js';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import { existsSync, readFileSync } from 'fs';
@@ -733,9 +736,8 @@ Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>`;
  * @param ciRun.status - CI run status
  * @param ciRun.conclusion - CI run conclusion
  * @param ciRun.name - CI run name
- * @param vercelUrls - Vercel preview URLs
- * @param vercelUrls.webUrl - Web app preview URL
- * @param vercelUrls.marketingUrl - Marketing app preview URL
+ * @param groupedPreviews - Preview URLs grouped by provider
+ * @param linkedIssues - Issue numbers linked from PR body
  * @returns Formatted message
  * @example
  */
@@ -743,7 +745,8 @@ function formatPRStatusWithCommit(
   commitSha: string,
   prCheck: { prNumber: number; prUrl: string },
   ciRun: { url?: string; status?: string; conclusion?: string; name?: string },
-  vercelUrls: { webUrl?: string; marketingUrl?: string }
+  groupedPreviews: GroupedPreviewUrls,
+  linkedIssues: number[]
 ): string {
   const ciPassed = ciRun.conclusion === 'success';
   const ciFailed = ciRun.conclusion === 'failure';
@@ -759,11 +762,36 @@ function formatPRStatusWithCommit(
     message += `🔄 CI: ${ciRun.url} ${statusIcon} ${ciRun.conclusion || ciRun.status || 'pending'}\n`;
   }
 
-  // Preview URLs
-  if (vercelUrls.webUrl || vercelUrls.marketingUrl) {
-    message += '\n🌐 Previews:\n';
-    if (vercelUrls.webUrl) message += `   • ${vercelUrls.webUrl}\n`;
-    if (vercelUrls.marketingUrl) message += `   • ${vercelUrls.marketingUrl}\n`;
+  // Linked issues (if any)
+  if (linkedIssues.length > 0) {
+    message += '\n📌 Linked Issue(s):\n';
+    for (const issueNum of linkedIssues) {
+      message += `   • #${issueNum}\n`;
+    }
+  }
+
+  // Vercel Previews
+  if (groupedPreviews.vercel.length > 0) {
+    message += '\n🔼 Vercel Previews:\n';
+    for (const url of groupedPreviews.vercel) {
+      message += `   • ${url}\n`;
+    }
+  }
+
+  // Cloudflare Previews
+  if (groupedPreviews.cloudflare.length > 0) {
+    message += '\n☁️ Cloudflare Worker Previews:\n';
+    for (const url of groupedPreviews.cloudflare) {
+      message += `   • ${url}\n`;
+    }
+  }
+
+  // Supabase Previews
+  if (groupedPreviews.supabase.length > 0) {
+    message += '\n⚡ Supabase Preview Branches:\n';
+    for (const url of groupedPreviews.supabase) {
+      message += `   • ${url}\n`;
+    }
   }
 
   message += '\nPress enter to continue.';
@@ -780,16 +808,16 @@ function formatPRStatusWithCommit(
  * @param ciRun.status - CI run status
  * @param ciRun.conclusion - CI run conclusion
  * @param ciRun.name - CI run name
- * @param vercelUrls - Vercel preview URLs
- * @param vercelUrls.webUrl - Web app preview URL
- * @param vercelUrls.marketingUrl - Marketing app preview URL
+ * @param groupedPreviews - Preview URLs grouped by provider
+ * @param linkedIssues - Issue numbers linked from PR body
  * @returns Formatted message
  * @example
  */
 function formatPRStatusInfo(
   prCheck: { prNumber: number; prUrl: string },
   ciRun: { url?: string; status?: string; conclusion?: string; name?: string },
-  vercelUrls: { webUrl?: string; marketingUrl?: string }
+  groupedPreviews: GroupedPreviewUrls,
+  linkedIssues: number[]
 ): string {
   // Header (simplified - this function only called when CI passed or pending)
   let message = '✅ PR Ready for Review\n\n';
@@ -802,11 +830,36 @@ function formatPRStatusInfo(
     message += `🔄 [View CI Run](${ciRun.url}) ✅ success\n`;
   }
 
-  // Preview URLs
-  if (vercelUrls.webUrl || vercelUrls.marketingUrl) {
-    message += '\n🌐 Previews:\n';
-    if (vercelUrls.webUrl) message += `   • ${vercelUrls.webUrl}\n`;
-    if (vercelUrls.marketingUrl) message += `   • ${vercelUrls.marketingUrl}\n`;
+  // Linked issues (if any)
+  if (linkedIssues.length > 0) {
+    message += '\n📌 Linked Issue(s):\n';
+    for (const issueNum of linkedIssues) {
+      message += `   • #${issueNum}\n`;
+    }
+  }
+
+  // Vercel Previews
+  if (groupedPreviews.vercel.length > 0) {
+    message += '\n🔼 Vercel Previews:\n';
+    for (const url of groupedPreviews.vercel) {
+      message += `   • ${url}\n`;
+    }
+  }
+
+  // Cloudflare Previews
+  if (groupedPreviews.cloudflare.length > 0) {
+    message += '\n☁️ Cloudflare Worker Previews:\n';
+    for (const url of groupedPreviews.cloudflare) {
+      message += `   • ${url}\n`;
+    }
+  }
+
+  // Supabase Previews
+  if (groupedPreviews.supabase.length > 0) {
+    message += '\n⚡ Supabase Preview Branches:\n';
+    for (const url of groupedPreviews.supabase) {
+      message += `   • ${url}\n`;
+    }
   }
 
   message += '\nPress enter to continue.';
@@ -1162,9 +1215,25 @@ ${checksTable}
         checks: ciResult.checks
       });
 
-      // Fetch PR details
-      const ciRun = await getCIRunDetails(prCheck.prNumber, repoRoot) ?? {};
-      const vercelUrls = await extractPreviewUrls(prCheck.prNumber, repoRoot);
+      // Fetch PR details, previews, and linked issues in parallel
+      const [ciRun, groupedPreviews, linkedIssues] = await Promise.all([
+        getCIRunDetails(prCheck.prNumber, repoRoot).then(r => r ?? {}),
+        extractAllPreviews(prCheck.prNumber, repoRoot),
+        extractLinkedIssuesFromPR(prCheck.prNumber, repoRoot),
+      ]);
+
+      // Track PR in github.json
+      await addPRToState(
+        input.session_id,
+        {
+          number: prCheck.prNumber,
+          url: prCheck.prUrl,
+          title: '', // We don't have title here, could fetch if needed
+          createdAt: new Date().toISOString(),
+          linkedIssues,
+        },
+        repoRoot
+      );
 
       // If CI run shows failure, block Claude (don't show to user)
       if (ciRun.conclusion === 'failure' || ciRun.conclusion === 'cancelled') {
@@ -1183,19 +1252,19 @@ ${checksTable}
         // Show PR status after commit (non-blocking)
         return {
           decision: 'approve',
-          systemMessage: formatPRStatusWithCommit(commitSha, { prNumber: prCheck.prNumber, prUrl: prCheck.prUrl }, ciRun, vercelUrls),
+          systemMessage: formatPRStatusWithCommit(commitSha, { prNumber: prCheck.prNumber, prUrl: prCheck.prUrl }, ciRun, groupedPreviews, linkedIssues),
         };
       } else if (commitsAheadOfMain > 0) {
         // Show PR status to user (non-blocking)
         return {
           decision: 'approve',
-          systemMessage: formatPRStatusInfo({ prNumber: prCheck.prNumber, prUrl: prCheck.prUrl }, ciRun, vercelUrls),
+          systemMessage: formatPRStatusInfo({ prNumber: prCheck.prNumber, prUrl: prCheck.prUrl }, ciRun, groupedPreviews, linkedIssues),
         };
       } else {
         // Always show PR status when PR exists, even if no new commits this session (non-blocking)
         return {
           decision: 'approve',
-          systemMessage: formatPRStatusInfo({ prNumber: prCheck.prNumber, prUrl: prCheck.prUrl }, ciRun, vercelUrls),
+          systemMessage: formatPRStatusInfo({ prNumber: prCheck.prNumber, prUrl: prCheck.prUrl }, ciRun, groupedPreviews, linkedIssues),
         };
       }
     }

--- a/plugins/github-orchestration/hooks/track-issue-creation.ts
+++ b/plugins/github-orchestration/hooks/track-issue-creation.ts
@@ -20,6 +20,7 @@ import type { PostToolUseInput, PostToolUseHookOutput } from '../shared/types/ty
 import { createDebugLogger } from '../shared/hooks/utils/debug.js';
 import { runHook } from '../shared/hooks/utils/io.js';
 import { addIssueToSession } from '../shared/hooks/utils/session-issues.js';
+import { addIssueToState } from '../shared/hooks/utils/github-state.js';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
@@ -195,7 +196,9 @@ async function handler(input: PostToolUseInput): Promise<PostToolUseHookOutput> 
 
     const branch = branchResult.stdout;
 
-    // Add issue to session tracking
+    const createdAt = new Date().toISOString();
+
+    // Add issue to session tracking (session-issues.json)
     await addIssueToSession(
       input.session_id,
       {
@@ -203,10 +206,22 @@ async function handler(input: PostToolUseInput): Promise<PostToolUseHookOutput> 
         number: issueNumber,
         title: issueDetails.title,
         url: issueUrl,
-        createdAt: new Date().toISOString(),
+        createdAt,
       },
       branch,
       repo,
+      input.cwd
+    );
+
+    // Also add issue to unified github.json state
+    await addIssueToState(
+      input.session_id,
+      {
+        number: issueNumber,
+        url: issueUrl,
+        title: issueDetails.title,
+        createdAt,
+      },
       input.cwd
     );
 

--- a/plugins/github-orchestration/shared/hooks/utils/ci-status.ts
+++ b/plugins/github-orchestration/shared/hooks/utils/ci-status.ts
@@ -133,6 +133,18 @@ export interface PreviewUrls {
 }
 
 /**
+ * Grouped preview URLs by provider
+ */
+export interface GroupedPreviewUrls {
+  /** Vercel preview URLs */
+  vercel: string[];
+  /** Cloudflare Worker/Pages preview URLs */
+  cloudflare: string[];
+  /** Supabase preview branch URLs */
+  supabase: string[];
+}
+
+/**
  * Execute a shell command with timeout
  *
  * @param command - Command to execute
@@ -448,6 +460,204 @@ export async function extractPreviewUrls(
   } catch {
     return { allUrls: [] };
   }
+}
+
+/**
+ * Extract linked issue numbers from PR body
+ *
+ * Parses PR body for GitHub issue-closing keywords like:
+ * - Fixes #123, Closes #456, Resolves #789
+ * - Full URLs: github.com/owner/repo/issues/123
+ *
+ * @param prNumber - PR number
+ * @param cwd - Working directory
+ * @returns Array of linked issue numbers (deduplicated and sorted)
+ *
+ * @example
+ * ```typescript
+ * const linkedIssues = await extractLinkedIssuesFromPR(42, '/path/to/repo');
+ * // Returns: [123, 456] if PR body contains "Fixes #123" and "Closes #456"
+ * ```
+ */
+export async function extractLinkedIssuesFromPR(
+  prNumber: number,
+  cwd: string
+): Promise<number[]> {
+  const result = await execCommand(
+    `gh pr view ${prNumber} --json body --jq '.body'`,
+    cwd
+  );
+
+  if (!result.success || !result.stdout) {
+    return [];
+  }
+
+  const body = result.stdout;
+  const linkedIssues: Set<number> = new Set();
+
+  // Pattern 1: Issue-closing keywords with # reference
+  // Matches: fix, fixes, fixed, close, closes, closed, resolve, resolves, resolved
+  const keywordPattern = /\b(?:fix|fixes|fixed|close|closes|closed|resolve|resolves|resolved)\s+#(\d+)/gi;
+  let match;
+  while ((match = keywordPattern.exec(body)) !== null) {
+    linkedIssues.add(parseInt(match[1], 10));
+  }
+
+  // Pattern 2: Full GitHub issue URLs
+  // Matches: https://github.com/owner/repo/issues/123
+  const urlPattern = /github\.com\/[^/]+\/[^/]+\/issues\/(\d+)/g;
+  while ((match = urlPattern.exec(body)) !== null) {
+    linkedIssues.add(parseInt(match[1], 10));
+  }
+
+  // Return sorted array
+  return Array.from(linkedIssues).sort((a, b) => a - b);
+}
+
+/**
+ * Extract Cloudflare Worker/Pages preview URLs from PR comments
+ *
+ * Searches PR comments for Cloudflare deployment URLs:
+ * - Workers: https://my-worker.workers.dev
+ * - Pages: https://my-project.pages.dev
+ *
+ * @param prNumber - PR number
+ * @param cwd - Working directory
+ * @returns Array of Cloudflare preview URLs
+ *
+ * @example
+ * ```typescript
+ * const urls = await extractCloudflarePreviewUrls(42, '/path/to/repo');
+ * // Returns: ['https://my-api.workers.dev', 'https://my-site.pages.dev']
+ * ```
+ */
+export async function extractCloudflarePreviewUrls(
+  prNumber: number,
+  cwd: string
+): Promise<string[]> {
+  const result = await execCommand(`gh pr view ${prNumber} --json comments`, cwd);
+
+  if (!result.success) {
+    return [];
+  }
+
+  try {
+    const data = JSON.parse(result.stdout);
+    const comments = data.comments || [];
+    const allUrls: string[] = [];
+
+    // Cloudflare Workers pattern: https://something.workers.dev
+    const workersPattern = /https:\/\/[a-z0-9-]+\.workers\.dev/gi;
+    // Cloudflare Pages pattern: https://something.pages.dev
+    const pagesPattern = /https:\/\/[a-z0-9-]+\.pages\.dev/gi;
+
+    for (const comment of comments) {
+      const body = comment.body || '';
+      const workersMatches = body.match(workersPattern) || [];
+      const pagesMatches = body.match(pagesPattern) || [];
+      allUrls.push(...workersMatches, ...pagesMatches);
+    }
+
+    // Deduplicate
+    return [...new Set(allUrls)];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Extract Supabase preview branch URLs from PR comments
+ *
+ * Searches PR comments for Supabase preview URLs:
+ * - API: https://project-ref.supabase.co
+ * - Database: db.project-ref.supabase.co
+ *
+ * @param prNumber - PR number
+ * @param cwd - Working directory
+ * @returns Array of Supabase preview URLs
+ *
+ * @example
+ * ```typescript
+ * const urls = await extractSupabasePreviewBranches(42, '/path/to/repo');
+ * // Returns: ['https://abcxyz-preview.supabase.co']
+ * ```
+ */
+export async function extractSupabasePreviewBranches(
+  prNumber: number,
+  cwd: string
+): Promise<string[]> {
+  const result = await execCommand(`gh pr view ${prNumber} --json comments`, cwd);
+
+  if (!result.success) {
+    return [];
+  }
+
+  try {
+    const data = JSON.parse(result.stdout);
+    const comments = data.comments || [];
+    const allUrls: string[] = [];
+
+    // Supabase API URL pattern: https://something.supabase.co
+    const supabasePattern = /https:\/\/[a-z0-9-]+\.supabase\.co/gi;
+    // Supabase DB URL pattern: db.something.supabase.co (may or may not have https://)
+    const dbPattern = /(?:https?:\/\/)?db\.[a-z0-9-]+\.supabase\.co/gi;
+
+    for (const comment of comments) {
+      const body = comment.body || '';
+      const supabaseMatches = body.match(supabasePattern) || [];
+      const dbMatches = body.match(dbPattern) || [];
+      allUrls.push(...supabaseMatches, ...dbMatches);
+    }
+
+    // Deduplicate and normalize (ensure https://)
+    const uniqueUrls = [...new Set(allUrls)].map((url) => {
+      if (!url.startsWith('http')) {
+        return `https://${url}`;
+      }
+      return url;
+    });
+
+    return uniqueUrls;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Extract all preview URLs grouped by provider
+ *
+ * Consolidates preview URLs from Vercel, Cloudflare, and Supabase.
+ *
+ * @param prNumber - PR number
+ * @param cwd - Working directory
+ * @returns Grouped preview URLs by provider
+ *
+ * @example
+ * ```typescript
+ * const previews = await extractAllPreviews(42, '/path/to/repo');
+ * // Returns: {
+ * //   vercel: ['https://my-app-abc123.vercel.app'],
+ * //   cloudflare: ['https://my-worker.workers.dev'],
+ * //   supabase: ['https://abcxyz.supabase.co']
+ * // }
+ * ```
+ */
+export async function extractAllPreviews(
+  prNumber: number,
+  cwd: string
+): Promise<GroupedPreviewUrls> {
+  // Fetch all previews in parallel
+  const [vercelResult, cloudflareUrls, supabaseUrls] = await Promise.all([
+    extractPreviewUrls(prNumber, cwd),
+    extractCloudflarePreviewUrls(prNumber, cwd),
+    extractSupabasePreviewBranches(prNumber, cwd),
+  ]);
+
+  return {
+    vercel: vercelResult.allUrls,
+    cloudflare: cloudflareUrls,
+    supabase: supabaseUrls,
+  };
 }
 
 /**

--- a/plugins/github-orchestration/shared/hooks/utils/github-state.ts
+++ b/plugins/github-orchestration/shared/hooks/utils/github-state.ts
@@ -1,0 +1,368 @@
+/**
+ * Unified GitHub session state management
+ *
+ * Manages tracking of GitHub PRs and issues created during Claude sessions
+ * in a single github.json file. This enables:
+ * - Cross-session awareness of related PRs and issues
+ * - Tracking linked issues from PR bodies
+ * - Unified state for session stop output
+ *
+ * State is stored in .claude/logs/github.json
+ *
+ * @module github-state
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const LOGS_DIR = '.claude/logs';
+const GITHUB_STATE_FILE = 'github.json';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Reference to a GitHub PR created during a session
+ */
+export interface SessionPR {
+  /**
+   * PR number
+   */
+  number: number;
+  /**
+   * Full GitHub PR URL
+   */
+  url: string;
+  /**
+   * PR title
+   */
+  title: string;
+  /**
+   * ISO timestamp when PR was created
+   */
+  createdAt: string;
+  /**
+   * Issue numbers linked via PR body (Fixes #123, etc.)
+   */
+  linkedIssues: number[];
+}
+
+/**
+ * Reference to a GitHub issue created during a session
+ */
+export interface SessionIssue {
+  /**
+   * Issue number
+   */
+  number: number;
+  /**
+   * Full GitHub issue URL
+   */
+  url: string;
+  /**
+   * Issue title
+   */
+  title: string;
+  /**
+   * ISO timestamp when issue was created
+   */
+  createdAt: string;
+}
+
+/**
+ * Complete GitHub session state
+ */
+export interface GitHubSessionState {
+  /**
+   * Session identifier
+   */
+  sessionId: string;
+  /**
+   * PRs created during this session
+   */
+  prs: SessionPR[];
+  /**
+   * Issues created during this session
+   */
+  issues: SessionIssue[];
+  /**
+   * ISO timestamp of last update
+   */
+  lastUpdated: string;
+}
+
+/**
+ * Map of session IDs to their GitHub state
+ */
+export interface GitHubStateFile {
+  [sessionId: string]: GitHubSessionState;
+}
+
+// ============================================================================
+// File Path Management
+// ============================================================================
+
+/**
+ * Get the path to github.json
+ * @param cwd - The working directory
+ * @param customPath - Optional custom path (for testing)
+ * @returns Full path to the github state file
+ */
+function getGitHubStateFilePath(cwd: string, customPath?: string): string {
+  return customPath || path.join(cwd, LOGS_DIR, GITHUB_STATE_FILE);
+}
+
+// ============================================================================
+// State Management
+// ============================================================================
+
+/**
+ * Load GitHub state from disk
+ *
+ * Loads all tracked sessions and their PRs/issues. If the file doesn't exist
+ * or is invalid, returns an empty state.
+ * @param cwd - The working directory where logs are stored
+ * @param statePath - Optional custom path for github.json (for testing)
+ * @returns The complete GitHub state
+ */
+export async function loadGitHubState(
+  cwd: string,
+  statePath?: string
+): Promise<GitHubStateFile> {
+  const filePath = getGitHubStateFilePath(cwd, statePath);
+
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(content);
+  } catch {
+    // File doesn't exist or parse error - return empty state
+    return {};
+  }
+}
+
+/**
+ * Save GitHub state to disk
+ *
+ * Persists the complete state to disk. Automatically creates the logs directory
+ * if it doesn't exist.
+ * @param cwd - The working directory where logs are stored
+ * @param state - The complete GitHub state to save
+ * @param statePath - Optional custom path for github.json (for testing)
+ * @returns Promise that resolves when state is saved
+ */
+async function saveGitHubState(
+  cwd: string,
+  state: GitHubStateFile,
+  statePath?: string
+): Promise<void> {
+  const filePath = getGitHubStateFilePath(cwd, statePath);
+
+  // Ensure directory exists
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify(state, null, 2), 'utf-8');
+}
+
+/**
+ * Get or create session state
+ * @param sessionId - Session identifier
+ * @param state - Current state file
+ * @returns Session state (existing or new)
+ */
+function getOrCreateSessionState(
+  sessionId: string,
+  state: GitHubStateFile
+): GitHubSessionState {
+  if (!state[sessionId]) {
+    state[sessionId] = {
+      sessionId,
+      prs: [],
+      issues: [],
+      lastUpdated: new Date().toISOString(),
+    };
+  }
+  return state[sessionId];
+}
+
+/**
+ * Add a PR to session state
+ *
+ * Records that a PR was created during a session. If the session doesn't exist,
+ * it will be created. Automatically enforces a 100-session limit.
+ * @param sessionId - The session ID
+ * @param pr - The PR reference to add
+ * @param cwd - The working directory where logs are stored
+ * @param statePath - Optional custom path for github.json (for testing)
+ * @returns Promise that resolves when the PR is added
+ */
+export async function addPRToState(
+  sessionId: string,
+  pr: SessionPR,
+  cwd: string,
+  statePath?: string
+): Promise<void> {
+  let state = await loadGitHubState(cwd, statePath);
+  const sessionState = getOrCreateSessionState(sessionId, state);
+
+  // Check if PR already exists (avoid duplicates)
+  const existingIndex = sessionState.prs.findIndex((p) => p.number === pr.number);
+  if (existingIndex >= 0) {
+    // Update existing PR (e.g., with new linked issues)
+    sessionState.prs[existingIndex] = pr;
+  } else {
+    sessionState.prs.push(pr);
+  }
+
+  sessionState.lastUpdated = new Date().toISOString();
+
+  // Limit to last 100 sessions
+  state = enforceSessionLimit(state, 100);
+
+  await saveGitHubState(cwd, state, statePath);
+}
+
+/**
+ * Add an issue to session state
+ *
+ * Records that an issue was created during a session. If the session doesn't exist,
+ * it will be created. Automatically enforces a 100-session limit.
+ * @param sessionId - The session ID
+ * @param issue - The issue reference to add
+ * @param cwd - The working directory where logs are stored
+ * @param statePath - Optional custom path for github.json (for testing)
+ * @returns Promise that resolves when the issue is added
+ */
+export async function addIssueToState(
+  sessionId: string,
+  issue: SessionIssue,
+  cwd: string,
+  statePath?: string
+): Promise<void> {
+  let state = await loadGitHubState(cwd, statePath);
+  const sessionState = getOrCreateSessionState(sessionId, state);
+
+  // Check if issue already exists (avoid duplicates)
+  const existingIndex = sessionState.issues.findIndex((i) => i.number === issue.number);
+  if (existingIndex >= 0) {
+    // Update existing issue
+    sessionState.issues[existingIndex] = issue;
+  } else {
+    sessionState.issues.push(issue);
+  }
+
+  sessionState.lastUpdated = new Date().toISOString();
+
+  // Limit to last 100 sessions
+  state = enforceSessionLimit(state, 100);
+
+  await saveGitHubState(cwd, state, statePath);
+}
+
+/**
+ * Get PRs created during a specific session
+ * @param sessionId - The session ID to query
+ * @param cwd - The working directory where logs are stored
+ * @param statePath - Optional custom path for github.json (for testing)
+ * @returns Array of PR references
+ */
+export async function getSessionPRs(
+  sessionId: string,
+  cwd: string,
+  statePath?: string
+): Promise<SessionPR[]> {
+  const state = await loadGitHubState(cwd, statePath);
+  return state[sessionId]?.prs || [];
+}
+
+/**
+ * Get issues created during a specific session
+ * @param sessionId - The session ID to query
+ * @param cwd - The working directory where logs are stored
+ * @param statePath - Optional custom path for github.json (for testing)
+ * @returns Array of issue references
+ */
+export async function getSessionIssuesFromState(
+  sessionId: string,
+  cwd: string,
+  statePath?: string
+): Promise<SessionIssue[]> {
+  const state = await loadGitHubState(cwd, statePath);
+  return state[sessionId]?.issues || [];
+}
+
+/**
+ * Get the full session state
+ * @param sessionId - The session ID to query
+ * @param cwd - The working directory where logs are stored
+ * @param statePath - Optional custom path for github.json (for testing)
+ * @returns Session state or null if not found
+ */
+export async function getSessionGitHubState(
+  sessionId: string,
+  cwd: string,
+  statePath?: string
+): Promise<GitHubSessionState | null> {
+  const state = await loadGitHubState(cwd, statePath);
+  return state[sessionId] || null;
+}
+
+/**
+ * Enforce session limit by removing oldest sessions
+ * @param state - Current state
+ * @param limit - Maximum number of sessions to keep
+ * @returns Updated state
+ */
+function enforceSessionLimit(state: GitHubStateFile, limit: number): GitHubStateFile {
+  const sessionIds = Object.keys(state);
+  if (sessionIds.length <= limit) {
+    return state;
+  }
+
+  // Sort by lastUpdated, keep newest
+  const sorted = sessionIds
+    .map((id) => ({ id, lastUpdated: state[id].lastUpdated }))
+    .sort((a, b) => new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime())
+    .slice(0, limit);
+
+  const newState: GitHubStateFile = {};
+  for (const { id } of sorted) {
+    newState[id] = state[id];
+  }
+  return newState;
+}
+
+/**
+ * Clean up old sessions from state file
+ * @param cwd - The working directory where logs are stored
+ * @param retentionDays - Number of days to retain sessions (default: 30)
+ * @param statePath - Optional custom path for github.json (for testing)
+ * @returns Promise that resolves when cleanup is complete
+ */
+export async function cleanupOldGitHubSessions(
+  cwd: string,
+  retentionDays: number = 30,
+  statePath?: string
+): Promise<void> {
+  const state = await loadGitHubState(cwd, statePath);
+  const cutoffTime = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+
+  let modified = false;
+  const newState: GitHubStateFile = {};
+
+  for (const [sessionId, session] of Object.entries(state)) {
+    const sessionTime = new Date(session.lastUpdated).getTime();
+    if (sessionTime >= cutoffTime) {
+      newState[sessionId] = session;
+    } else {
+      modified = true;
+    }
+  }
+
+  if (modified) {
+    await saveGitHubState(cwd, newState, statePath);
+  }
+}


### PR DESCRIPTION
## Summary

- Add unified `github-state.ts` for tracking PRs and issues in `.claude/logs/github.json`
- Add preview URL extraction for Cloudflare Workers/Pages and Supabase
- Add linked issue parsing from PR body (Fixes #123, Closes #456 keywords)
- Update session stop output with grouped preview sections by provider
- Update PostToolUse hooks to write to github.json

## Test plan

- [ ] Create a PR with body containing "Fixes #123"
- [ ] Verify session stop shows "📌 Linked Issue(s):" section with #123
- [ ] Verify session stop shows grouped preview URLs by provider (Vercel/Cloudflare/Supabase)
- [ ] Verify `.claude/logs/github.json` contains PR and issue data
- [ ] Run `npm run typecheck` to verify no type errors
- [ ] Run `npm run lint` to verify no lint errors

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)