### PR TITLE
feat: Move ESLint/Vitest/Typecheck hooks to nextjs-supabase-ai-sdk-dev

### DIFF
--- a/plugins/nextjs-supabase-ai-sdk-dev/CLAUDE.md
+++ b/plugins/nextjs-supabase-ai-sdk-dev/CLAUDE.md
@@ -22,7 +22,12 @@ Local dev environment setup for Vercel/Supabase and systematic UI development wi
 | install-vercel | SessionStart | No | Installs Vercel CLI |
 | install-start-supabase-next | SessionStart | No | Sets up Supabase local dev, installs dependencies (skips if fresh), starts dev servers (Next.js, Cloudflare, Elysia, Turborepo) with health checks |
 | cache-supabase-schema | SessionStart | No | Caches Supabase table/column metadata for context matching |
+| run-file-eslint | PostToolUse[Write\|Edit] | Yes | Runs ESLint on edited files |
+| run-file-vitests | PostToolUse[Write\|Edit] | No | Runs related tests (warns only) |
 | move-playwright-screenshots | PostToolUse[browser_eval] | No | Moves screenshots to .claude/screenshots/ to prevent permission prompts |
+| run-task-vitests | SubagentStop | Yes | Runs tests for all task edits |
+| run-task-typechecks | SubagentStop | Yes | Runs tsc --noEmit after task |
+| run-session-typechecks | Stop | Yes | Runs tsc --noEmit before session stops |
 | cleanup-supabase-session | SessionEnd | No | Stops Supabase containers, restores config.toml, marks session stopped |
 
 ## Agents

--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/hooks.json
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/hooks.json
@@ -60,12 +60,54 @@
     ],
     "PostToolUse": [
       {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/run-file-eslint.ts",
+            "description": "Runs ESLint on edited .ts/.tsx/.js/.jsx files. Blocking on errors."
+          },
+          {
+            "type": "command",
+            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/run-file-vitests.ts",
+            "description": "Runs related vitest tests for edited files. Non-blocking (warns only)."
+          }
+        ]
+      },
+      {
         "matcher": "browser_eval",
         "hooks": [
           {
             "type": "command",
             "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/move-playwright-screenshots.ts",
             "description": "Moves screenshots to .claude/screenshots/ to prevent permission prompts"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/run-task-vitests.ts",
+            "description": "Runs vitest for all files edited during agent's task. Blocking on failure."
+          },
+          {
+            "type": "command",
+            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/run-task-typechecks.ts",
+            "description": "Runs tsc --noEmit after agent completes. Blocking on type errors."
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/run-session-typechecks.ts",
+            "description": "Runs tsc --noEmit before session stops. Blocking on type errors."
           }
         ]
       }

--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/run-file-eslint.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/run-file-eslint.ts
@@ -1,0 +1,117 @@
+/**
+ * ESLint check for PostToolUse[Write|Edit] hooks
+ *
+ * Runs eslint on the edited file and blocks if there are errors.
+ * Only runs on .ts, .tsx, .js, .jsx files.
+ *
+ * @module run-file-eslint
+ */
+
+import type { PostToolUseInput, PostToolUseHookOutput } from '../shared/types/types.js';
+import { runHook } from '../shared/hooks/utils/io.js';
+import { findConfigFile } from '../shared/hooks/utils/config-resolver.js';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+/** Maximum characters for check output to prevent context bloat */
+const MAX_OUTPUT_CHARS = 500;
+
+/** Timeout for eslint in milliseconds (30 seconds) */
+const TIMEOUT_MS = 30000;
+
+/** File extensions to lint */
+const LINT_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx'];
+
+/**
+ * Truncate output to MAX_OUTPUT_CHARS
+ */
+function truncateOutput(output: string): string {
+  if (output.length <= MAX_OUTPUT_CHARS) {
+    return output;
+  }
+
+  const truncated = output.slice(0, MAX_OUTPUT_CHARS);
+  const remaining = output.length - MAX_OUTPUT_CHARS;
+  return `${truncated}\n... (${remaining} more chars truncated)`;
+}
+
+/**
+ * Check if file should be linted based on extension
+ */
+function shouldLint(filePath: string): boolean {
+  return LINT_EXTENSIONS.some((ext) => filePath.endsWith(ext));
+}
+
+/**
+ * PostToolUse[Write|Edit] hook handler
+ *
+ * Runs eslint on the edited file. Blocks if eslint fails.
+ */
+async function handler(input: PostToolUseInput): Promise<PostToolUseHookOutput> {
+  // Only process Write and Edit tools
+  if (input.tool_name !== 'Write' && input.tool_name !== 'Edit') {
+    return {};
+  }
+
+  // Get file path from tool input
+  const toolInput = input.tool_input as { file_path?: string };
+  const filePath = toolInput?.file_path;
+
+  if (!filePath || !shouldLint(filePath)) {
+    return {};
+  }
+
+  // Find eslint config directory
+  let eslintConfigDir = await findConfigFile(input.cwd, 'eslint.config.mjs');
+
+  // Try alternative flat config format
+  if (!eslintConfigDir) {
+    eslintConfigDir = await findConfigFile(input.cwd, 'eslint.config.js');
+  }
+
+  if (!eslintConfigDir) {
+    // No ESLint flat config found - skip validation with warning
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext: `⚠️ ESLint config not found (searched from ${input.cwd} to git root). Skipping lint check. Expected: eslint.config.mjs or eslint.config.js`,
+      },
+    };
+  }
+
+  // Run eslint
+  const command = `npx eslint --max-warnings 0 "${filePath}"`;
+
+  try {
+    await execAsync(command, {
+      cwd: eslintConfigDir,
+      timeout: TIMEOUT_MS,
+    });
+
+    // ESLint passed
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext: `✓ ESLint passed`,
+      },
+    };
+  } catch (error) {
+    // ESLint failed
+    const err = error as { stdout?: string; stderr?: string; message?: string };
+    const output = err.stdout || err.stderr || err.message || 'ESLint failed';
+
+    return {
+      decision: 'block',
+      reason: `Fix ESLint errors before continuing:\n\n${truncateOutput(output)}`,
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext: `❌ ESLint failed:\n\n${truncateOutput(output)}`,
+      },
+    };
+  }
+}
+
+export { handler };
+runHook(handler);

--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/run-file-vitests.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/run-file-vitests.ts
@@ -1,0 +1,159 @@
+/**
+ * Vitest check for PostToolUse[Write|Edit] hooks
+ *
+ * Runs vitest for related tests when a file is edited.
+ * Non-blocking - only warns if tests fail.
+ * Only runs on .ts, .tsx files.
+ *
+ * @module run-file-vitests
+ */
+
+import type { PostToolUseInput, PostToolUseHookOutput } from '../shared/types/types.js';
+import { runHook } from '../shared/hooks/utils/io.js';
+import { findConfigFile } from '../shared/hooks/utils/config-resolver.js';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { access } from 'fs/promises';
+import { basename, dirname, join, relative, isAbsolute } from 'path';
+
+const execAsync = promisify(exec);
+
+/** Maximum characters for check output to prevent context bloat */
+const MAX_OUTPUT_CHARS = 500;
+
+/** Timeout for vitest in milliseconds (30 seconds) */
+const TIMEOUT_MS = 30000;
+
+/** File extensions to check for tests */
+const TEST_EXTENSIONS = ['.ts', '.tsx'];
+
+/**
+ * Truncate output to MAX_OUTPUT_CHARS
+ */
+function truncateOutput(output: string): string {
+  if (output.length <= MAX_OUTPUT_CHARS) {
+    return output;
+  }
+
+  const truncated = output.slice(0, MAX_OUTPUT_CHARS);
+  const remaining = output.length - MAX_OUTPUT_CHARS;
+  return `${truncated}\n... (${remaining} more chars truncated)`;
+}
+
+/**
+ * Check if file should have tests checked
+ */
+function shouldCheckTests(filePath: string): boolean {
+  // Don't run tests for test files themselves
+  if (filePath.includes('.test.') || filePath.includes('.spec.')) {
+    return false;
+  }
+  return TEST_EXTENSIONS.some((ext) => filePath.endsWith(ext));
+}
+
+/**
+ * Find the test file for a given source file
+ * Looks for foo.test.ts or foo.test.tsx next to the source file
+ */
+async function findTestFile(filePath: string): Promise<string | null> {
+  const dir = dirname(filePath);
+  const base = basename(filePath);
+
+  // Remove extension to get base name
+  const extMatch = base.match(/\.(ts|tsx)$/);
+  if (!extMatch) return null;
+
+  const nameWithoutExt = base.slice(0, -extMatch[0].length);
+
+  // Try .test.ts and .test.tsx
+  for (const ext of ['.test.ts', '.test.tsx']) {
+    const testPath = join(dir, nameWithoutExt + ext);
+    try {
+      await access(testPath);
+      return testPath;
+    } catch {
+      // File doesn't exist
+    }
+  }
+
+  return null;
+}
+
+/**
+ * PostToolUse[Write|Edit] hook handler
+ *
+ * Runs vitest for related tests. Non-blocking - warns only.
+ */
+async function handler(input: PostToolUseInput): Promise<PostToolUseHookOutput> {
+  // Only process Write and Edit tools
+  if (input.tool_name !== 'Write' && input.tool_name !== 'Edit') {
+    return {};
+  }
+
+  // Get file path from tool input
+  const toolInput = input.tool_input as { file_path?: string };
+  const filePath = toolInput?.file_path;
+
+  if (!filePath || !shouldCheckTests(filePath)) {
+    return {};
+  }
+
+  // Find related test file
+  const testFile = await findTestFile(filePath);
+
+  if (!testFile) {
+    // No test file found, skip silently
+    return {};
+  }
+
+  // Find vitest config
+  let vitestConfigDir = await findConfigFile(input.cwd, 'vitest.config.ts');
+
+  // Try alternative configs
+  if (!vitestConfigDir) {
+    vitestConfigDir = await findConfigFile(input.cwd, 'vitest.config.js');
+  }
+  if (!vitestConfigDir) {
+    vitestConfigDir = await findConfigFile(input.cwd, 'vitest.config.mjs');
+  }
+
+  // Fallback to input.cwd if no config found
+  const runDir = vitestConfigDir || input.cwd;
+
+  // Make test file path relative to run directory
+  const relativeTestFile = isAbsolute(testFile)
+    ? relative(runDir, testFile)
+    : testFile;
+
+  // Run vitest for the test file
+  const command = `npx vitest run "${relativeTestFile}" --reporter=verbose`;
+
+  try {
+    await execAsync(command, {
+      cwd: runDir,
+      timeout: TIMEOUT_MS,
+    });
+
+    // Tests passed
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext: `✓ Tests passed for ${basename(testFile)}`,
+      },
+    };
+  } catch (error) {
+    // Tests failed - warn but don't block
+    const err = error as { stdout?: string; stderr?: string; message?: string };
+    const output = err.stdout || err.stderr || err.message || 'Tests failed';
+
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse',
+        additionalContext: `⚠️ Tests failed for ${basename(testFile)}:\n\n${truncateOutput(output)}`,
+      },
+    };
+  }
+}
+
+export { handler };
+runHook(handler);

--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/run-session-typechecks.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/run-session-typechecks.ts
@@ -1,0 +1,129 @@
+/**
+ * TypeScript check for Stop hooks
+ *
+ * Runs tsc --noEmit on the project before the main session stops.
+ * Blocks if there are type errors.
+ *
+ * @module run-session-typechecks
+ */
+
+import type { StopInput, StopHookOutput } from '../shared/types/types.js';
+import { runHook } from '../shared/hooks/utils/io.js';
+import { parseTranscript, getNewFiles, getEditedFiles } from '../shared/hooks/utils/transcripts.js';
+import { findConfigFile } from '../shared/hooks/utils/config-resolver.js';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+/** Maximum characters for check output to prevent context bloat */
+const MAX_OUTPUT_CHARS = 500;
+
+/** Timeout for tsc in milliseconds (60 seconds - tsc can be slow) */
+const TIMEOUT_MS = 60000;
+
+/** File extensions that trigger typecheck */
+const TS_EXTENSIONS = ['.ts', '.tsx'];
+
+/**
+ * Truncate output to MAX_OUTPUT_CHARS
+ */
+function truncateOutput(output: string): string {
+  if (output.length <= MAX_OUTPUT_CHARS) {
+    return output;
+  }
+
+  const truncated = output.slice(0, MAX_OUTPUT_CHARS);
+  const remaining = output.length - MAX_OUTPUT_CHARS;
+  return `${truncated}\n... (${remaining} more chars truncated)`;
+}
+
+/**
+ * Check if any edited files are TypeScript
+ */
+function hasTypeScriptFiles(files: string[]): boolean {
+  return files.some((file) =>
+    TS_EXTENSIONS.some((ext) => file.endsWith(ext))
+  );
+}
+
+/**
+ * Stop hook handler
+ *
+ * Runs tsc --noEmit on the project. Blocks if typecheck fails.
+ */
+async function handler(input: StopInput): Promise<StopHookOutput> {
+  const DEBUG = process.env.DEBUG === '*' || process.env.DEBUG?.includes('session-typechecks');
+
+  if (DEBUG) {
+    console.log('[run-session-typechecks] Hook triggered');
+    console.log('[run-session-typechecks] Session ID:', input.session_id);
+  }
+
+  try {
+    // Parse the main session transcript to get all edited files
+    const transcript = await parseTranscript(input.transcript_path);
+    const newFiles = getNewFiles(transcript);
+    const editedFiles = getEditedFiles(transcript);
+    const allEditedFiles = [...new Set([...newFiles, ...editedFiles])];
+
+    if (DEBUG) {
+      console.log('[run-session-typechecks] Edited files:', allEditedFiles.length);
+    }
+
+    // Only run typecheck if TypeScript files were edited
+    if (!hasTypeScriptFiles(allEditedFiles)) {
+      if (DEBUG) {
+        console.log('[run-session-typechecks] No TypeScript files edited, skipping');
+      }
+      return {};
+    }
+
+    // Find tsconfig.json
+    const tsconfigDir = await findConfigFile(input.cwd, 'tsconfig.json');
+
+    if (!tsconfigDir) {
+      // No tsconfig.json found - skip with warning
+      if (DEBUG) {
+        console.warn(`[run-session-typechecks] TypeScript configuration (tsconfig.json) not found. Searched from ${input.cwd} to git root. Skipping type check.`);
+      }
+      return {};
+    }
+
+    // Run tsc --noEmit on the project
+    const command = 'npx tsc --noEmit';
+
+    if (DEBUG) {
+      console.log('[run-session-typechecks] Running:', command);
+      console.log('[run-session-typechecks] Config dir:', tsconfigDir);
+    }
+
+    try {
+      await execAsync(command, {
+        cwd: tsconfigDir,
+        timeout: TIMEOUT_MS,
+      });
+
+      // Typecheck passed
+      return {};
+    } catch (error) {
+      // Typecheck failed
+      const err = error as { stdout?: string; stderr?: string; message?: string };
+      const output = err.stdout || err.stderr || err.message || 'TypeScript check failed';
+
+      return {
+        decision: 'block',
+        reason: `Fix TypeScript errors before continuing:\n\n${truncateOutput(output)}`,
+      };
+    }
+  } catch (error) {
+    if (DEBUG) {
+      console.error('[run-session-typechecks] Error:', error);
+    }
+    // Don't block on transcript parsing errors
+    return {};
+  }
+}
+
+export { handler };
+runHook(handler);

--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/run-task-typechecks.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/run-task-typechecks.ts
@@ -1,0 +1,127 @@
+/**
+ * TypeScript check for SubagentStop hooks
+ *
+ * Runs tsc --noEmit on the project after a subagent completes.
+ * Blocks if there are type errors.
+ *
+ * @module run-task-typechecks
+ */
+
+import type { SubagentStopInput, SubagentStopHookOutput } from '../shared/types/types.js';
+import { runHook } from '../shared/hooks/utils/io.js';
+import { getAgentEdits } from '../shared/hooks/utils/subagent-state.js';
+import { findConfigFile } from '../shared/hooks/utils/config-resolver.js';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+/** Maximum characters for check output to prevent context bloat */
+const MAX_OUTPUT_CHARS = 500;
+
+/** Timeout for tsc in milliseconds (60 seconds - tsc can be slow) */
+const TIMEOUT_MS = 60000;
+
+/** File extensions that trigger typecheck */
+const TS_EXTENSIONS = ['.ts', '.tsx'];
+
+/**
+ * Truncate output to MAX_OUTPUT_CHARS
+ */
+function truncateOutput(output: string): string {
+  if (output.length <= MAX_OUTPUT_CHARS) {
+    return output;
+  }
+
+  const truncated = output.slice(0, MAX_OUTPUT_CHARS);
+  const remaining = output.length - MAX_OUTPUT_CHARS;
+  return `${truncated}\n... (${remaining} more chars truncated)`;
+}
+
+/**
+ * Check if any edited files are TypeScript
+ */
+function hasTypeScriptFiles(files: string[]): boolean {
+  return files.some((file) =>
+    TS_EXTENSIONS.some((ext) => file.endsWith(ext))
+  );
+}
+
+/**
+ * SubagentStop hook handler
+ *
+ * Runs tsc --noEmit on the project. Blocks if typecheck fails.
+ */
+async function handler(input: SubagentStopInput): Promise<SubagentStopHookOutput> {
+  const DEBUG = process.env.DEBUG === '*' || process.env.DEBUG?.includes('task-typechecks');
+
+  if (DEBUG) {
+    console.log('[run-task-typechecks] Hook triggered');
+    console.log('[run-task-typechecks] Agent ID:', input.agent_id);
+  }
+
+  try {
+    // Get all files edited by the agent
+    const edits = await getAgentEdits(input.agent_transcript_path);
+    const allEditedFiles = [...edits.agentNewFiles, ...edits.agentEditedFiles];
+
+    if (DEBUG) {
+      console.log('[run-task-typechecks] Edited files:', allEditedFiles.length);
+    }
+
+    // Only run typecheck if TypeScript files were edited
+    if (!hasTypeScriptFiles(allEditedFiles)) {
+      if (DEBUG) {
+        console.log('[run-task-typechecks] No TypeScript files edited, skipping');
+      }
+      return {};
+    }
+
+    // Find tsconfig.json
+    const tsconfigDir = await findConfigFile(input.cwd, 'tsconfig.json');
+
+    if (!tsconfigDir) {
+      // No tsconfig.json found - skip with warning (per user preference)
+      if (DEBUG) {
+        console.warn(`[run-task-typechecks] TypeScript configuration (tsconfig.json) not found. Searched from ${input.cwd} to git root. Skipping type check.`);
+      }
+      return {};
+    }
+
+    // Run tsc --noEmit on the project
+    const command = 'npx tsc --noEmit';
+
+    if (DEBUG) {
+      console.log('[run-task-typechecks] Running:', command);
+      console.log('[run-task-typechecks] Config dir:', tsconfigDir);
+    }
+
+    try {
+      await execAsync(command, {
+        cwd: tsconfigDir,
+        timeout: TIMEOUT_MS,
+      });
+
+      // Typecheck passed
+      return {};
+    } catch (error) {
+      // Typecheck failed
+      const err = error as { stdout?: string; stderr?: string; message?: string };
+      const output = err.stdout || err.stderr || err.message || 'TypeScript check failed';
+
+      return {
+        decision: 'block',
+        reason: `Fix TypeScript errors before continuing:\n\n${truncateOutput(output)}`,
+      };
+    }
+  } catch (error) {
+    if (DEBUG) {
+      console.error('[run-task-typechecks] Error:', error);
+    }
+    // Don't block on transcript parsing errors
+    return {};
+  }
+}
+
+export { handler };
+runHook(handler);

--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/run-task-vitests.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/run-task-vitests.ts
@@ -1,0 +1,147 @@
+/**
+ * Vitest check for SubagentStop hooks
+ *
+ * Runs vitest for all files edited during the agent's task.
+ * Blocks if tests fail.
+ *
+ * @module run-task-vitests
+ */
+
+import type { SubagentStopInput, SubagentStopHookOutput } from '../shared/types/types.js';
+import { runHook } from '../shared/hooks/utils/io.js';
+import { getAgentEdits } from '../shared/hooks/utils/subagent-state.js';
+import { findConfigFile } from '../shared/hooks/utils/config-resolver.js';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import * as path from 'path';
+
+const execAsync = promisify(exec);
+
+/** Maximum characters for check output to prevent context bloat */
+const MAX_OUTPUT_CHARS = 500;
+
+/** Timeout for vitest in milliseconds (30 seconds) */
+const TIMEOUT_MS = 30000;
+
+/** File extensions to check for tests */
+const TEST_EXTENSIONS = ['.ts', '.tsx'];
+
+/**
+ * Truncate output to MAX_OUTPUT_CHARS
+ */
+function truncateOutput(output: string): string {
+  if (output.length <= MAX_OUTPUT_CHARS) {
+    return output;
+  }
+
+  const truncated = output.slice(0, MAX_OUTPUT_CHARS);
+  const remaining = output.length - MAX_OUTPUT_CHARS;
+  return `${truncated}\n... (${remaining} more chars truncated)`;
+}
+
+/**
+ * Filter to only testable files
+ */
+function getTestableFiles(files: string[]): string[] {
+  return files.filter((file) => {
+    // Skip test files themselves
+    if (file.includes('.test.') || file.includes('.spec.')) {
+      return false;
+    }
+    return TEST_EXTENSIONS.some((ext) => file.endsWith(ext));
+  });
+}
+
+/**
+ * SubagentStop hook handler
+ *
+ * Runs vitest related for all edited files. Blocks if tests fail.
+ */
+async function handler(input: SubagentStopInput): Promise<SubagentStopHookOutput> {
+  const DEBUG = process.env.DEBUG === '*' || process.env.DEBUG?.includes('task-vitests');
+
+  if (DEBUG) {
+    console.log('[run-task-vitests] Hook triggered');
+    console.log('[run-task-vitests] Agent ID:', input.agent_id);
+  }
+
+  try {
+    // Get all files edited by the agent
+    const edits = await getAgentEdits(input.agent_transcript_path);
+    const allEditedFiles = [...edits.agentNewFiles, ...edits.agentEditedFiles];
+    const testableFiles = getTestableFiles(allEditedFiles);
+
+    if (DEBUG) {
+      console.log('[run-task-vitests] Edited files:', allEditedFiles.length);
+      console.log('[run-task-vitests] Testable files:', testableFiles.length);
+    }
+
+    if (testableFiles.length === 0) {
+      // No testable files, skip
+      return {};
+    }
+
+    // Find vitest config
+    let vitestConfigDir = await findConfigFile(input.cwd, 'vitest.config.ts');
+
+    // Try alternative config formats
+    if (!vitestConfigDir) {
+      vitestConfigDir = await findConfigFile(input.cwd, 'vitest.config.js');
+    }
+    if (!vitestConfigDir) {
+      vitestConfigDir = await findConfigFile(input.cwd, 'vitest.config.mjs');
+    }
+
+    // Fallback to input.cwd if no config found (Vitest has defaults)
+    const runDir = vitestConfigDir || input.cwd;
+
+    if (!vitestConfigDir && DEBUG) {
+      console.warn(`[run-task-vitests] No vitest config found (searched from ${input.cwd}). Running with defaults.`);
+    }
+
+    // Make file paths relative to run directory
+    const relativeFiles = testableFiles.map(f => {
+      if (path.isAbsolute(f)) {
+        return path.relative(runDir, f);
+      }
+      return f;
+    });
+
+    // Run vitest related for all edited files
+    const filesArg = relativeFiles.map((f) => `"${f}"`).join(' ');
+    const command = `npx vitest related ${filesArg} --run --reporter=verbose`;
+
+    if (DEBUG) {
+      console.log('[run-task-vitests] Running:', command);
+      console.log('[run-task-vitests] Config dir:', runDir);
+    }
+
+    try {
+      await execAsync(command, {
+        cwd: runDir,
+        timeout: TIMEOUT_MS,
+      });
+
+      // Tests passed
+      return {};
+    } catch (error) {
+      // Tests failed
+      const err = error as { stdout?: string; stderr?: string; message?: string };
+      const output = err.stdout || err.stderr || err.message || 'Tests failed';
+
+      return {
+        decision: 'block',
+        reason: `Fix test failures before continuing:\n\n${truncateOutput(output)}`,
+      };
+    }
+  } catch (error) {
+    if (DEBUG) {
+      console.error('[run-task-vitests] Error:', error);
+    }
+    // Don't block on transcript parsing errors
+    return {};
+  }
+}
+
+export { handler };
+runHook(handler);

--- a/plugins/project-context/CLAUDE.md
+++ b/plugins/project-context/CLAUDE.md
@@ -26,12 +26,8 @@ Automatic CLAUDE.md discovery, .claude structure validation, and rule-based chec
 | validate-folder-structure-mkdir | PreToolUse[Bash] | Yes | Validates mkdir commands |
 | try-markdown-page | PreToolUse[WebFetch] | No | Redirects to .md URLs |
 | log-task-result | PostToolUse[Task] | No | Logs task results |
-| run-file-eslint | PostToolUse[Write\|Edit] | Yes | Runs ESLint on edited files |
-| run-file-vitests | PostToolUse[Write\|Edit] | No | Runs related tests (warns only) |
 | track-task-scope | PostToolUse[Write\|Edit] | No | Advisory when file outside task scope |
 | add-folder-context | PostToolUse[Read] | No | Discovers CLAUDE.md files |
-| run-task-vitests | SubagentStop | Yes | Runs tests for all task edits |
-| run-task-typechecks | SubagentStop | Yes | Runs tsc --noEmit after task |
 
 ## Skills
 

--- a/plugins/project-context/hooks/hooks.json
+++ b/plugins/project-context/hooks/hooks.json
@@ -87,36 +87,10 @@
       ]
     }
   ],
-  "SubagentStop": [
-    {
-      "hooks": [
-        {
-          "type": "command",
-          "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/run-task-vitests.ts",
-          "description": "Runs vitest for all files edited during the agent's task. Blocking on failure, 500 char limit."
-        },
-        {
-          "type": "command",
-          "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/run-task-typechecks.ts",
-          "description": "Runs tsc --noEmit after agent completes. Blocking on type errors, 500 char limit."
-        }
-      ]
-    }
-  ],
   "PostToolUse": [
     {
       "matcher": "Write|Edit",
       "hooks": [
-        {
-          "type": "command",
-          "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/run-file-eslint.ts",
-          "description": "Runs ESLint on edited .ts/.tsx/.js/.jsx files. Blocking on errors, 500 char limit."
-        },
-        {
-          "type": "command",
-          "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/run-file-vitests.ts",
-          "description": "Runs related vitest tests for edited files. Non-blocking (warns only), 500 char limit."
-        },
         {
           "type": "command",
           "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/track-task-scope.ts",


### PR DESCRIPTION
## Summary

- Move code quality hooks (ESLint, Vitest, Typecheck) from `project-context` to `nextjs-supabase-ai-sdk-dev` plugin
- Add new Stop hook for typecheck that runs before main session ends

## Changes

### Files Created (in nextjs-supabase-ai-sdk-dev/hooks/)
- `run-file-eslint.ts` - PostToolUse[Write|Edit] hook for ESLint (blocking on errors)
- `run-file-vitests.ts` - PostToolUse[Write|Edit] hook for related tests (warns only)
- `run-task-vitests.ts` - SubagentStop hook for all edited files (blocking)
- `run-task-typechecks.ts` - SubagentStop hook for typecheck (blocking)
- `run-session-typechecks.ts` - **New** Stop hook for typecheck before session ends (blocking)

### Files Modified
- `nextjs-supabase-ai-sdk-dev/hooks/hooks.json` - Added PostToolUse, SubagentStop, and Stop sections
- `project-context/hooks/hooks.json` - Removed SubagentStop section and eslint/vitest from PostToolUse
- Both `CLAUDE.md` files - Updated hook summary tables

## Hook Behavior

| Event | Hook | Behavior |
|-------|------|----------|
| PostToolUse[Write\|Edit] | run-file-eslint | **Blocks** on ESLint errors |
| PostToolUse[Write\|Edit] | run-file-vitests | **Warns** on test failures |
| SubagentStop | run-task-vitests | **Blocks** on test failures |
| SubagentStop | run-task-typechecks | **Blocks** on type errors |
| Stop | run-session-typechecks | **Blocks** on type errors |

## Test plan

- [ ] Edit a TypeScript file with a type error → should see typecheck fail on SubagentStop or Stop
- [ ] Edit a TypeScript file with eslint error → should see eslint block on PostToolUse
- [ ] Edit a file with related test → should see vitest run (warn on failure)

Closes #296

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>