### PR TITLE
fix: Make Stop and SubagentStop TypeScript hooks reliable with visibility

### DIFF
--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/run-session-typechecks.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/run-session-typechecks.ts
@@ -9,7 +9,6 @@
 
 import type { StopInput, StopHookOutput } from '../shared/types/types.js';
 import { runHook } from '../shared/hooks/utils/io.js';
-import { parseTranscript, getNewFiles, getEditedFiles } from '../shared/hooks/utils/transcripts.js';
 import { findConfigFile } from '../shared/hooks/utils/config-resolver.js';
 import { exec } from 'child_process';
 import { promisify } from 'util';
@@ -21,9 +20,6 @@ const MAX_OUTPUT_CHARS = 500;
 
 /** Timeout for tsc in milliseconds (60 seconds - tsc can be slow) */
 const TIMEOUT_MS = 60000;
-
-/** File extensions that trigger typecheck */
-const TS_EXTENSIONS = ['.ts', '.tsx'];
 
 /**
  * Truncate output to MAX_OUTPUT_CHARS
@@ -39,18 +35,11 @@ function truncateOutput(output: string): string {
 }
 
 /**
- * Check if any edited files are TypeScript
- */
-function hasTypeScriptFiles(files: string[]): boolean {
-  return files.some((file) =>
-    TS_EXTENSIONS.some((ext) => file.endsWith(ext))
-  );
-}
-
-/**
  * Stop hook handler
  *
- * Runs tsc --noEmit on the project. Blocks if typecheck fails.
+ * Runs tsc --noEmit on the project unconditionally. Session Stop is the
+ * final checkpoint before work completes, so running tsc on the whole
+ * project is reasonable overhead.
  */
 async function handler(input: StopInput): Promise<StopHookOutput> {
   const DEBUG = process.env.DEBUG === '*' || process.env.DEBUG?.includes('session-typechecks');
@@ -60,68 +49,47 @@ async function handler(input: StopInput): Promise<StopHookOutput> {
     console.log('[run-session-typechecks] Session ID:', input.session_id);
   }
 
+  // Find tsconfig.json
+  const tsconfigDir = await findConfigFile(input.cwd, 'tsconfig.json');
+
+  if (!tsconfigDir) {
+    // No tsconfig.json found - skip with warning visible in systemMessage
+    const warning = `⚠️ TypeScript check skipped: tsconfig.json not found (searched from ${input.cwd})`;
+    if (DEBUG) {
+      console.warn(`[run-session-typechecks] ${warning}`);
+    }
+    return {
+      systemMessage: warning,
+    };
+  }
+
+  // Run tsc --noEmit on the project
+  const command = 'npx tsc --noEmit';
+
+  if (DEBUG) {
+    console.log('[run-session-typechecks] Running:', command);
+    console.log('[run-session-typechecks] Config dir:', tsconfigDir);
+  }
+
   try {
-    // Parse the main session transcript to get all edited files
-    const transcript = await parseTranscript(input.transcript_path);
-    const newFiles = getNewFiles(transcript);
-    const editedFiles = getEditedFiles(transcript);
-    const allEditedFiles = [...new Set([...newFiles, ...editedFiles])];
+    await execAsync(command, {
+      cwd: tsconfigDir,
+      timeout: TIMEOUT_MS,
+    });
 
-    if (DEBUG) {
-      console.log('[run-session-typechecks] Edited files:', allEditedFiles.length);
-    }
-
-    // Only run typecheck if TypeScript files were edited
-    if (!hasTypeScriptFiles(allEditedFiles)) {
-      if (DEBUG) {
-        console.log('[run-session-typechecks] No TypeScript files edited, skipping');
-      }
-      return {};
-    }
-
-    // Find tsconfig.json
-    const tsconfigDir = await findConfigFile(input.cwd, 'tsconfig.json');
-
-    if (!tsconfigDir) {
-      // No tsconfig.json found - skip with warning
-      if (DEBUG) {
-        console.warn(`[run-session-typechecks] TypeScript configuration (tsconfig.json) not found. Searched from ${input.cwd} to git root. Skipping type check.`);
-      }
-      return {};
-    }
-
-    // Run tsc --noEmit on the project
-    const command = 'npx tsc --noEmit';
-
-    if (DEBUG) {
-      console.log('[run-session-typechecks] Running:', command);
-      console.log('[run-session-typechecks] Config dir:', tsconfigDir);
-    }
-
-    try {
-      await execAsync(command, {
-        cwd: tsconfigDir,
-        timeout: TIMEOUT_MS,
-      });
-
-      // Typecheck passed
-      return {};
-    } catch (error) {
-      // Typecheck failed
-      const err = error as { stdout?: string; stderr?: string; message?: string };
-      const output = err.stdout || err.stderr || err.message || 'TypeScript check failed';
-
-      return {
-        decision: 'block',
-        reason: `Fix TypeScript errors before continuing:\n\n${truncateOutput(output)}`,
-      };
-    }
+    // Typecheck passed - provide visibility
+    return {
+      systemMessage: '✓ TypeScript check passed',
+    };
   } catch (error) {
-    if (DEBUG) {
-      console.error('[run-session-typechecks] Error:', error);
-    }
-    // Don't block on transcript parsing errors
-    return {};
+    // Typecheck failed
+    const err = error as { stdout?: string; stderr?: string; message?: string };
+    const output = err.stdout || err.stderr || err.message || 'TypeScript check failed';
+
+    return {
+      decision: 'block',
+      reason: `Fix TypeScript errors before continuing:\n\n${truncateOutput(output)}`,
+    };
   }
 }
 

--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/run-task-typechecks.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/run-task-typechecks.ts
@@ -50,7 +50,8 @@ function hasTypeScriptFiles(files: string[]): boolean {
 /**
  * SubagentStop hook handler
  *
- * Runs tsc --noEmit on the project. Blocks if typecheck fails.
+ * Runs tsc --noEmit on the project if TypeScript files were edited.
+ * Blocks if typecheck fails.
  */
 async function handler(input: SubagentStopInput): Promise<SubagentStopHookOutput> {
   const DEBUG = process.env.DEBUG === '*' || process.env.DEBUG?.includes('task-typechecks');
@@ -60,66 +61,78 @@ async function handler(input: SubagentStopInput): Promise<SubagentStopHookOutput
     console.log('[run-task-typechecks] Agent ID:', input.agent_id);
   }
 
+  // Get all files edited by the agent
+  let allEditedFiles: string[];
   try {
-    // Get all files edited by the agent
     const edits = await getAgentEdits(input.agent_transcript_path);
-    const allEditedFiles = [...edits.agentNewFiles, ...edits.agentEditedFiles];
-
-    if (DEBUG) {
-      console.log('[run-task-typechecks] Edited files:', allEditedFiles.length);
-    }
-
-    // Only run typecheck if TypeScript files were edited
-    if (!hasTypeScriptFiles(allEditedFiles)) {
-      if (DEBUG) {
-        console.log('[run-task-typechecks] No TypeScript files edited, skipping');
-      }
-      return {};
-    }
-
-    // Find tsconfig.json
-    const tsconfigDir = await findConfigFile(input.cwd, 'tsconfig.json');
-
-    if (!tsconfigDir) {
-      // No tsconfig.json found - skip with warning (per user preference)
-      if (DEBUG) {
-        console.warn(`[run-task-typechecks] TypeScript configuration (tsconfig.json) not found. Searched from ${input.cwd} to git root. Skipping type check.`);
-      }
-      return {};
-    }
-
-    // Run tsc --noEmit on the project
-    const command = 'npx tsc --noEmit';
-
-    if (DEBUG) {
-      console.log('[run-task-typechecks] Running:', command);
-      console.log('[run-task-typechecks] Config dir:', tsconfigDir);
-    }
-
-    try {
-      await execAsync(command, {
-        cwd: tsconfigDir,
-        timeout: TIMEOUT_MS,
-      });
-
-      // Typecheck passed
-      return {};
-    } catch (error) {
-      // Typecheck failed
-      const err = error as { stdout?: string; stderr?: string; message?: string };
-      const output = err.stdout || err.stderr || err.message || 'TypeScript check failed';
-
-      return {
-        decision: 'block',
-        reason: `Fix TypeScript errors before continuing:\n\n${truncateOutput(output)}`,
-      };
-    }
+    allEditedFiles = [...edits.agentNewFiles, ...edits.agentEditedFiles];
   } catch (error) {
+    // Transcript parsing failed - provide visibility instead of silent failure
+    const err = error as Error;
+    const warning = `⚠️ TypeScript check skipped: Could not parse agent transcript (${err.message})`;
     if (DEBUG) {
-      console.error('[run-task-typechecks] Error:', error);
+      console.error('[run-task-typechecks] Error parsing transcript:', error);
     }
-    // Don't block on transcript parsing errors
-    return {};
+    return {
+      systemMessage: warning,
+    };
+  }
+
+  if (DEBUG) {
+    console.log('[run-task-typechecks] Edited files:', allEditedFiles.length);
+  }
+
+  // Only run typecheck if TypeScript files were edited
+  if (!hasTypeScriptFiles(allEditedFiles)) {
+    if (DEBUG) {
+      console.log('[run-task-typechecks] No TypeScript files edited, skipping');
+    }
+    return {
+      systemMessage: '✓ TypeScript check skipped (no .ts/.tsx files edited)',
+    };
+  }
+
+  // Find tsconfig.json
+  const tsconfigDir = await findConfigFile(input.cwd, 'tsconfig.json');
+
+  if (!tsconfigDir) {
+    // No tsconfig.json found - skip with warning visible in systemMessage
+    const warning = `⚠️ TypeScript check skipped: tsconfig.json not found (searched from ${input.cwd})`;
+    if (DEBUG) {
+      console.warn(`[run-task-typechecks] ${warning}`);
+    }
+    return {
+      systemMessage: warning,
+    };
+  }
+
+  // Run tsc --noEmit on the project
+  const command = 'npx tsc --noEmit';
+
+  if (DEBUG) {
+    console.log('[run-task-typechecks] Running:', command);
+    console.log('[run-task-typechecks] Config dir:', tsconfigDir);
+  }
+
+  try {
+    await execAsync(command, {
+      cwd: tsconfigDir,
+      timeout: TIMEOUT_MS,
+    });
+
+    // Typecheck passed - provide visibility
+    return {
+      systemMessage: '✓ TypeScript check passed',
+    };
+  } catch (error) {
+    // Typecheck failed
+    const err = error as { stdout?: string; stderr?: string; message?: string };
+    const output = err.stdout || err.stderr || err.message || 'TypeScript check failed';
+
+    return {
+      decision: 'block',
+      reason: `Fix TypeScript errors before continuing:\n\n${truncateOutput(output)}`,
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
- **Stop hook**: Runs `tsc --noEmit` unconditionally instead of parsing transcript (which could silently fail)
- **SubagentStop hook**: Adds visible warnings when transcript parsing fails instead of silent `return {}`
- **Both hooks**: Return `systemMessage` for visibility on success ("✓ TypeScript check passed") and skip conditions

Fixes #298

## Changes

### Stop hook (`run-session-typechecks.ts`)
- Removed transcript dependency - no longer parses transcript to find edited files
- Runs `tsc --noEmit` unconditionally - Session Stop is the final checkpoint, so full project check is reasonable
- Added visibility via `systemMessage`:
  - `✓ TypeScript check passed` on success
  - `⚠️ TypeScript check skipped: tsconfig.json not found...` when missing config
- Removed silent failure - no more outer try/catch that swallows errors

### SubagentStop hook (`run-task-typechecks.ts`)
- Kept agent edits check - only runs tsc if the agent edited TypeScript files
- Fixed silent failure - transcript parsing errors now return visible warning via `systemMessage`
- Added visibility via `systemMessage`:
  - `✓ TypeScript check passed` on success
  - `✓ TypeScript check skipped (no .ts/.tsx files edited)` when no TS files edited
  - `⚠️ TypeScript check skipped: Could not parse agent transcript (...)` on parsing errors

## Test plan
- [x] Create a file with TypeScript error in plugins directory
- [x] Verify `tsc --noEmit` catches the error (exit code 2)
- [x] Remove the test file
- [x] Verify `tsc --noEmit` passes (exit code 0)
- [x] ESLint passes on both hooks
- [x] TypeScript check passes on the project

🤖 Generated with [Claude Code](https://claude.com/claude-code)