### PR TITLE
Test: GitHub Orchestration Stacked PR Workflow

### DIFF
--- a/plugins/github-orchestration/shared/hooks/utils/task-state.ts
+++ b/plugins/github-orchestration/shared/hooks/utils/task-state.ts
@@ -336,7 +336,13 @@ export async function getTaskEdits(
   }
 
   // Find parent session transcript
-  const dir = path.dirname(agentTranscriptPath);
+  // Agent transcripts are at: .../project/{sessionId}/subagents/agent-{agentId}.jsonl
+  // Parent transcripts are at: .../project/{sessionId}.jsonl
+  let dir = path.dirname(agentTranscriptPath); // .../sessionId/subagents/
+  if (path.basename(dir) === 'subagents') {
+    dir = path.dirname(dir); // .../sessionId/
+  }
+  dir = path.dirname(dir); // .../project/
   const parentPath = path.join(dir, `${sessionId}.jsonl`);
 
   try {

--- a/plugins/github-orchestration/tests/stacked-pr-workflow.test.md
+++ b/plugins/github-orchestration/tests/stacked-pr-workflow.test.md
@@ -29,4 +29,63 @@
 
 ## Results
 
-_To be filled after test execution_
+### Test Run 1 (07:33 UTC)
+- **Subissue #313** ✅ Created with labels `task`, `subissue`
+- **Native sub-issue API** ❌ Returns `[]` (using markdown fallback)
+- **Stacked branch** ❌ Not created (no active PR detected yet)
+
+### Test Run 2 (07:35 UTC)
+- **Subissue #315** ✅ Created with labels `task`, `subissue`
+- **Stacked branch** ✅ Created: `311-fix/can-u-test-out-the-gh-orchestration-plug-subagent-a18c360`
+- **Stacked PR** ❌ Failed - Bug in `getTaskEdits()` (wrong parent transcript path)
+- **Branch cleanup** ✅ Ran (deleted branch due to error)
+
+### Bug Found
+**File**: `plugins/github-orchestration/shared/hooks/utils/task-state.ts:340`
+
+**Issue**: `getTaskEdits()` constructs wrong path for parent transcript
+- Agent transcript: `.../project/{sessionId}/subagents/agent-{agentId}.jsonl`
+- Code looked for: `.../project/{sessionId}/subagents/{sessionId}.jsonl` ❌
+- Should look for: `.../project/{sessionId}.jsonl` ✅
+
+**Fix Applied**: Go up two directory levels from agent transcript path
+
+### Test Run 3 (07:38 UTC)
+- **Subissue #316** ✅ Created with labels `task`, `subissue`
+- **Stacked branch** ✅ Created but cleaned up due to error
+- **Stacked PR** ❌ Still failing (fix not in plugin cache yet)
+- **Note**: Fix applied to source but hooks run from `~/.claude/plugins/cache/constellos-local/`
+
+## Summary
+
+| Hook | Status | Notes |
+|------|--------|-------|
+| `sync-task-to-subissue.ts` | ✅ Working | Creates subissues linked to parent |
+| `create-subagent-branch.ts` | ✅ Working | Creates branch when PR exists |
+| `stacked-pr-subagent-stop.ts` | ❌ Bug | Path calculation error - fixed in source |
+
+### Issues Created During Test
+- #313, #315, #316 - All linked to parent #311
+
+### PRs Created
+- #312 - Main PR (this branch → main)
+- No stacked PRs (blocked by bug)
+
+### Fix Required
+File: `plugins/github-orchestration/shared/hooks/utils/task-state.ts`
+
+Before:
+```typescript
+const dir = path.dirname(agentTranscriptPath);
+const parentPath = path.join(dir, `${sessionId}.jsonl`);
+```
+
+After:
+```typescript
+let dir = path.dirname(agentTranscriptPath);
+if (path.basename(dir) === 'subagents') {
+  dir = path.dirname(dir);
+}
+dir = path.dirname(dir);
+const parentPath = path.join(dir, `${sessionId}.jsonl`);
+```

--- a/plugins/github-orchestration/tests/utils/test-helpers.ts
+++ b/plugins/github-orchestration/tests/utils/test-helpers.ts
@@ -1,0 +1,24 @@
+/**
+ * Formats a test result with a pass/fail prefix.
+ * @param passed - Whether the test passed
+ * @param message - The test result message
+ * @returns Formatted string like "[PASS] message" or "[FAIL] message"
+ */
+export function formatTestResult(passed: boolean, message: string): string {
+  const prefix = passed ? '[PASS]' : '[FAIL]';
+  return `${prefix} ${message}`;
+}
+
+export function assertTestPassed(condition: boolean, testName: string): void {
+  if (!condition) {
+    throw new Error(`Test failed: ${testName}`);
+  }
+  console.log(formatTestResult(true, testName));
+}
+
+let testCounter = 0;
+
+export function getNextTestId(): string {
+  testCounter++;
+  return `test-${testCounter}`;
+}


### PR DESCRIPTION
## Summary

Testing the github-orchestration plugin's stacked PR workflow:

- Subagent tasks create subissues linked to parent issues (#311)
- PRs reference subissues with "Closes #X"
- PRs stack correctly (subagent-branch → this branch → main)

## Test Scope

| Hook | Event | Purpose |
|------|-------|---------|
| `sync-task-to-subissue.ts` | PostToolUse[Task] | Creates subissue linked to parent |
| `create-subagent-branch.ts` | SubagentStart | Creates isolated branch for subagent |
| `stacked-pr-subagent-stop.ts` | SubagentStop | Creates PR with "Closes #subissue" |

## Test Plan

See issue #311 for full test plan.

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)