### PR TITLE
fix(project-context): Apply parent transcript path fix from PR #312

### DIFF
--- a/plugins/project-context/shared/hooks/utils/task-state.ts
+++ b/plugins/project-context/shared/hooks/utils/task-state.ts
@@ -336,7 +336,13 @@ export async function getTaskEdits(
   }
 
   // Find parent session transcript
-  const dir = path.dirname(agentTranscriptPath);
+  // Agent transcripts are at: .../project/{sessionId}/subagents/agent-{agentId}.jsonl
+  // Parent transcripts are at: .../project/{sessionId}.jsonl
+  let dir = path.dirname(agentTranscriptPath); // .../sessionId/subagents/
+  if (path.basename(dir) === 'subagents') {
+    dir = path.dirname(dir); // .../sessionId/
+  }
+  dir = path.dirname(dir); // .../project/
   const parentPath = path.join(dir, `${sessionId}.jsonl`);
 
   try {

--- a/test-stacked-pr-workflow.txt
+++ b/test-stacked-pr-workflow.txt
@@ -1,1 +1,0 @@
-Testing stacked PR workflow hooks


### PR DESCRIPTION
## Summary

- Applied missing path fix from PR #312 to project-context plugin's `task-state.ts`
- Conducted live testing of stacked PR workflow and prompt-based hooks
- Identified issues with plugin cache dependency resolution

## Test Results

| Test | Status | Notes |
|------|--------|-------|
| **Subissue Creation** | ✅ PASS | Created subissue #319 linked to #317 |
| **Plan Agent Blocking** | ⚠️ BUG FIXED | Missing path fix applied |
| **Stop Hook** | ✅ Working | Prompt-based evaluation fires correctly |

## Bug Found & Fixed

The `project-context/shared/hooks/utils/task-state.ts` was missing the path calculation fix from PR #312:

```typescript
// Before (buggy)
const dir = path.dirname(agentTranscriptPath);
const parentPath = path.join(dir, `${sessionId}.jsonl`);

// After (fixed)
let dir = path.dirname(agentTranscriptPath);
if (path.basename(dir) === 'subagents') {
  dir = path.dirname(dir);
}
dir = path.dirname(dir);
const parentPath = path.join(dir, `${sessionId}.jsonl`);
```

## Known Issue

The review-subagent-completion hook fails silently in production because the cached plugin doesn't have `node_modules` with the `minimatch` dependency. This causes the hook to catch an error and return `{}` (passthrough) instead of blocking.

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)