### PR TITLE
feat: Disable local dev startup hook & enhance preview URL display

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -91,8 +91,8 @@
   "enabledPlugins": {
     "plugin-dev@claude-code-plugins": true,
     "feature-dev@claude-code-plugins": true,
-    "nextjs-supabase-ai-sdk-dev@constellos": true,
-    "github-orchestration@constellos": true
+    "github-orchestration@constellos": true,
+    "nextjs-supabase-ai-sdk-dev@constellos": true
   },
   "extraKnownMarketplaces": {
     "claude-code-plugins": {

--- a/plugins/github-orchestration/hooks/await-pr-status.ts
+++ b/plugins/github-orchestration/hooks/await-pr-status.ts
@@ -29,8 +29,9 @@ import {
 import {
   awaitCIWithFailFast,
   getLatestCIRun,
-  extractPreviewUrls,
+  extractAllPreviews,
   extractLinkedIssuesFromPR,
+  formatGroupedPreviews,
 } from '../shared/hooks/utils/ci-status.js';
 import { addPRToState } from '../shared/hooks/utils/github-state.js';
 
@@ -106,9 +107,9 @@ async function handler(
     const ciResult = await awaitCIWithFailFast({ prNumber }, input.cwd);
 
     // Get latest CI run details, preview URLs, and linked issues in parallel
-    const [ciRun, previewUrls, linkedIssues] = await Promise.all([
+    const [ciRun, groupedPreviews, linkedIssues] = await Promise.all([
       getLatestCIRun(prNumber, input.cwd),
-      extractPreviewUrls(prNumber, input.cwd),
+      extractAllPreviews(prNumber, input.cwd),
       extractLinkedIssuesFromPR(prNumber, input.cwd),
     ]);
 
@@ -169,18 +170,18 @@ async function handler(
       statusMessage += `\n🔗 [CI Run](${ciRun.url})`;
     }
 
-    // Add Vercel preview URLs (concise)
-    if (previewUrls.allUrls.length > 0) {
-      statusMessage += `\n🔗 Preview: ${previewUrls.allUrls[0]}`;
-      if (previewUrls.allUrls.length > 1) {
-        statusMessage += ` (+${previewUrls.allUrls.length - 1} more)`;
-      }
+    // Add all preview URLs grouped by provider
+    const previewSection = formatGroupedPreviews(groupedPreviews);
+    if (previewSection) {
+      statusMessage += previewSection;
     }
 
     await logger.logOutput({
       success: ciResult.success,
       ci_status: ciRun?.status,
-      vercel_urls: previewUrls.allUrls,
+      vercel_urls: groupedPreviews.vercel,
+      cloudflare_urls: groupedPreviews.cloudflare,
+      supabase_urls: groupedPreviews.supabase,
     });
 
     return {

--- a/plugins/github-orchestration/shared/hooks/utils/ci-status.ts
+++ b/plugins/github-orchestration/shared/hooks/utils/ci-status.ts
@@ -739,6 +739,56 @@ export async function extractAllPreviews(
 }
 
 /**
+ * Format grouped preview URLs for display
+ *
+ * Formats preview URLs from all providers (Vercel, Cloudflare, Supabase)
+ * into a markdown-formatted string with provider sections.
+ *
+ * @param previews - Grouped preview URLs by provider
+ * @returns Formatted markdown string, empty if no previews
+ *
+ * @example
+ * ```typescript
+ * const previews = await extractAllPreviews(42, '/path/to/repo');
+ * const formatted = formatGroupedPreviews(previews);
+ * // Returns:
+ * // "
+ * // **Vercel Previews:**
+ * //    - https://my-app-abc123.vercel.app
+ * //
+ * // **Cloudflare Previews:**
+ * //    - https://my-worker.workers.dev
+ * // "
+ * ```
+ */
+export function formatGroupedPreviews(previews: GroupedPreviewUrls): string {
+  let message = '';
+
+  if (previews.vercel.length > 0) {
+    message += '\n\n**Vercel Previews:**';
+    for (const url of previews.vercel) {
+      message += `\n   - ${url}`;
+    }
+  }
+
+  if (previews.cloudflare.length > 0) {
+    message += '\n\n**Cloudflare Previews:**';
+    for (const url of previews.cloudflare) {
+      message += `\n   - ${url}`;
+    }
+  }
+
+  if (previews.supabase.length > 0) {
+    message += '\n\n**Supabase Previews:**';
+    for (const url of previews.supabase) {
+      message += `\n   - ${url}`;
+    }
+  }
+
+  return message;
+}
+
+/**
  * Parse CI checks output into structured format
  *
  * @param output - Raw output from `gh pr checks`

--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/hooks.json
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/hooks.json
@@ -6,6 +6,25 @@
     "Tracks task/agent calls for context",
     "Check hooks moved to rule-based system in project-context plugin"
   ],
+  "_disabled_hooks": {
+    "_note": "Disabled hooks preserved for future re-enabling",
+    "SessionStart": [
+      {
+        "type": "command",
+        "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/install-start-supabase-next.ts",
+        "description": "Sets up Supabase local dev: installs CLI, starts Docker, starts Supabase, exports env vars, starts dev server",
+        "timeout": 600
+      }
+    ],
+    "SessionEnd": [
+      {
+        "type": "command",
+        "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/cleanup-supabase-session.ts",
+        "description": "Stops Supabase containers and marks session as stopped when session ends",
+        "timeout": 60
+      }
+    ]
+  },
   "description": "Local development environment setup for Next.js, Supabase, and AI SDK projects",
   "hooks": {
     "SessionStart": [
@@ -26,12 +45,6 @@
             "type": "command",
             "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/link-vercel-apps.ts",
             "description": "Auto-links monorepo apps to Vercel projects and pulls env vars"
-          },
-          {
-            "type": "command",
-            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/install-start-supabase-next.ts",
-            "description": "Sets up Supabase local dev: installs CLI, starts Docker, starts Supabase, exports env vars, starts dev server",
-            "timeout": 600
           },
           {
             "type": "command",
@@ -108,18 +121,6 @@
             "type": "command",
             "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/run-session-typechecks.ts",
             "description": "Runs tsc --noEmit before session stops. Blocking on type errors."
-          }
-        ]
-      }
-    ],
-    "SessionEnd": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/cleanup-supabase-session.ts",
-            "description": "Stops Supabase containers and marks session as stopped when session ends",
-            "timeout": 60
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Disable Docker/Supabase/dev server startup hook by moving to `_disabled_hooks` section (preserved for future re-enabling)
- Add `formatGroupedPreviews()` shared function for consistent preview URL formatting
- Update PR hook to show ALL preview URLs grouped by provider (Vercel, Cloudflare, Supabase)

## Test plan

- [ ] Start a new Claude session - verify Docker/Supabase are NOT started
- [ ] Verify other SessionStart hooks still run (setup-nodes-config, install-vercel, etc.)
- [ ] Create a PR with `gh pr create` - verify all preview URLs are shown grouped by provider
- [ ] End a session with open PR - verify stop hook still shows grouped previews

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)