### PR TITLE
Guard auto-commit hooks and cw against main branch

### DIFF
--- a/claude-worktree.sh
+++ b/claude-worktree.sh
@@ -609,6 +609,14 @@ _cw_main() {
   local suffix=$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 8)
   local branch_name="claude-${adj}-${name}-${suffix}"
 
+  # Defense-in-depth: reject if generated name matches a protected branch
+  case "$branch_name" in
+    main|master|develop)
+      echo "Error: Generated branch name '$branch_name' matches a protected branch."
+      return 1
+      ;;
+  esac
+
   # Check if we're in a git repository
   if ! git rev-parse --is-inside-work-tree &>/dev/null; then
     echo "Not in a git repo, launching claude normally..."

--- a/plugins/github-orchestration/hooks/commit-session-await-ci-status.ts
+++ b/plugins/github-orchestration/hooks/commit-session-await-ci-status.ts
@@ -1148,46 +1148,57 @@ async function handler(input: StopInput): Promise<StopHookOutput> {
 
     if (hasChanges) {
       const branch = await getCurrentBranch(repoRoot);
+      const protectedBranches = ['main', 'master', 'develop'];
+      const isProtectedBranch = branch !== null && protectedBranches.includes(branch);
 
-      // Only stage non-gitignored files
-      const filesToStage = await getNonIgnoredChanges(repoRoot);
-      if (filesToStage.length === 0) {
-        // All changes are gitignored - skip commit
-        await logger.logOutput({ skipped: true, reason: 'All changes are gitignored' });
-      } else {
-        // Stage only non-ignored files
-        for (const file of filesToStage) {
-          await execCommand(`git add "${file}"`, repoRoot);
-        }
+      if (isProtectedBranch) {
+        await logger.logOutput({
+          skipped: true,
+          reason: `Refusing to auto-commit on protected branch: ${branch}`,
+        });
+      }
 
-        const commitMessage = formatCommitMessage(input.session_id, branch);
-        const commitResult = await execCommand(
-          `git commit -m ${JSON.stringify(commitMessage)}`,
-          repoRoot
-        );
-
-        if (commitResult.success) {
-          const shaResult = await execCommand('git rev-parse HEAD', repoRoot);
-          const fullSha = shaResult.success ? shaResult.stdout : null;
-          commitSha = fullSha ? fullSha.substring(0, 7) : 'unknown';
-          commitMade = true;
-
-          await logger.logOutput({ commit_made: true, commit_sha: commitSha });
-
-          // Update state with new commit SHA for tracking
-          await updateSessionStopState(input.session_id, {
-            blockCount: sessionState.blockCount + 1,
-            lastBlockTimestamp: new Date().toISOString(),
-            lastSeenCommitSha: fullSha || undefined,
-          }, repoRoot);
-
-          // Re-check branch sync after commit
-          const postCommitSync = await checkBranchSync(repoRoot);
-          syncCheck.aheadBy = postCommitSync.aheadBy;
-          // Also update commits ahead of main
-          commitsAheadOfMain = await getCommitsAheadOfMain(repoRoot);
+      if (!isProtectedBranch) {
+        // Only stage non-gitignored files
+        const filesToStage = await getNonIgnoredChanges(repoRoot);
+        if (filesToStage.length === 0) {
+          // All changes are gitignored - skip commit
+          await logger.logOutput({ skipped: true, reason: 'All changes are gitignored' });
         } else {
-          await logger.logOutput({ commit_failed: true, error: commitResult.stderr });
+          // Stage only non-ignored files
+          for (const file of filesToStage) {
+            await execCommand(`git add "${file}"`, repoRoot);
+          }
+
+          const commitMessage = formatCommitMessage(input.session_id, branch);
+          const commitResult = await execCommand(
+            `git commit -m ${JSON.stringify(commitMessage)}`,
+            repoRoot
+          );
+
+          if (commitResult.success) {
+            const shaResult = await execCommand('git rev-parse HEAD', repoRoot);
+            const fullSha = shaResult.success ? shaResult.stdout : null;
+            commitSha = fullSha ? fullSha.substring(0, 7) : 'unknown';
+            commitMade = true;
+
+            await logger.logOutput({ commit_made: true, commit_sha: commitSha });
+
+            // Update state with new commit SHA for tracking
+            await updateSessionStopState(input.session_id, {
+              blockCount: sessionState.blockCount + 1,
+              lastBlockTimestamp: new Date().toISOString(),
+              lastSeenCommitSha: fullSha || undefined,
+            }, repoRoot);
+
+            // Re-check branch sync after commit
+            const postCommitSync = await checkBranchSync(repoRoot);
+            syncCheck.aheadBy = postCommitSync.aheadBy;
+            // Also update commits ahead of main
+            commitsAheadOfMain = await getCommitsAheadOfMain(repoRoot);
+          } else {
+            await logger.logOutput({ commit_failed: true, error: commitResult.stderr });
+          }
         }
       }
     }

--- a/plugins/github-orchestration/hooks/commit-task-await-ci-status.ts
+++ b/plugins/github-orchestration/hooks/commit-task-await-ci-status.ts
@@ -121,6 +121,18 @@ async function handler(
       return {};
     }
 
+    // Refuse to auto-commit on protected branches
+    const branchResult = await execCommand('git rev-parse --abbrev-ref HEAD', input.cwd);
+    const currentBranch = branchResult.success ? branchResult.stdout : null;
+    const protectedBranches = ['main', 'master', 'develop'];
+    if (currentBranch && protectedBranches.includes(currentBranch)) {
+      await logger.logOutput({
+        skipped: true,
+        reason: `Refusing to auto-commit on protected branch: ${currentBranch}`,
+      });
+      return {};
+    }
+
     // Get task edits (file operations and prompt)
     let taskEdits;
     try {


### PR DESCRIPTION
## Summary

- Add protected branch guard (`main`, `master`, `develop`) to `commit-session-await-ci-status.ts` Stop hook — skips auto-commit while still allowing Phase 3 PR status check to proceed
- Add protected branch guard with early return to `commit-task-await-ci-status.ts` SubagentStop hook
- Add defense-in-depth `case` validation in `claude-worktree.sh` to reject generated branch names matching protected branches

Closes #334

## Context

A worktree checked out on `main` caused the Stop hook to fire repeatedly, committing directly to local `main` and advancing it past `origin/main`. This broke `cw` which requires local `main` to track `origin/main`.

## Test plan

- [ ] `bun run typecheck` passes
- [ ] `bun run test` passes
- [ ] Manual: create worktree, checkout main, make a change, stop session — confirm hook logs "Refusing to auto-commit on protected branch: main" and does NOT commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)