### PR TITLE
Fix phantom Vercel projects + rename repo to claude-code

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ Add to your `~/.bashrc` or `~/.zshrc`:
 
 ```bash
 # Claude Worktree launcher with tab completion
-source ~/constellos/claude-code-plugins/claude-worktree.sh
+source ~/constellos/claude-code/claude-worktree.sh
 ```
 
 Then reload your shell:
@@ -439,7 +439,7 @@ cw nodes-md
 
 # Jump to a repo by owner/name
 cw celestian-dev/lazyjobs
-cw constellos/claude-code-plugins
+cw constellos/claude-code
 
 # Pass CLI flags to Claude
 cw --verbose

--- a/claude-worktree.sh
+++ b/claude-worktree.sh
@@ -16,7 +16,7 @@
 #   cw --verbose                # Current dir with claude flags
 #
 # Setup (add to ~/.bashrc or ~/.zshrc):
-#   source ~/constellos/claude-code-plugins/claude-worktree.sh
+#   source ~/constellos/claude-code/claude-worktree.sh
 #
 # Self-Update:
 #   The script auto-updates from origin/main when sourced or called.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3063,6 +3063,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "claude-code-plugins",
+  "name": "claude-code",
   "version": "1.0.0",
   "description": "Claude Code plugin collection - hook utilities and development tools",
   "type": "module",
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/constellos/claude-code-plugins.git"
+    "url": "git+https://github.com/constellos/claude-code.git"
   },
   "author": "constellos",
   "license": "MIT",

--- a/plugins/cloudflare-mcp-server-dev/.claude-plugin/plugin.json
+++ b/plugins/cloudflare-mcp-server-dev/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "constellos"
   },
-  "repository": "https://github.com/constellos/claude-code-plugins",
+  "repository": "https://github.com/constellos/claude-code",
   "license": "MIT",
   "keywords": [
     "cloudflare",

--- a/plugins/cloudflare-mcp-server-dev/README.md
+++ b/plugins/cloudflare-mcp-server-dev/README.md
@@ -21,7 +21,7 @@ This plugin provides access to Cloudflare's managed MCP servers for developing a
 
 ```bash
 # Add the constellos marketplace
-claude plugin marketplace add https://github.com/constellos/claude-code-plugins
+claude plugin marketplace add https://github.com/constellos/claude-code
 
 # Install this plugin
 claude plugin install cloudflare-workers-mcp-dev@constellos

--- a/plugins/essential-logging/.claude-plugin/plugin.json
+++ b/plugins/essential-logging/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "constellos"
   },
-  "repository": "https://github.com/constellos/claude-code-plugins",
+  "repository": "https://github.com/constellos/claude-code",
   "license": "MIT",
   "keywords": ["logging", "task-tracking", "transcripts", "core"],
   "hooks": "./hooks/hooks.json"

--- a/plugins/github-orchestration/.claude-plugin/plugin.json
+++ b/plugins/github-orchestration/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "constellos"
   },
-  "repository": "https://github.com/constellos/claude-code-plugins",
+  "repository": "https://github.com/constellos/claude-code",
   "license": "MIT",
   "keywords": ["github", "orchestration", "workflow", "issues", "pr", "ci", "automation"],
   "hooks": "./hooks/hooks.json"

--- a/plugins/nextjs-supabase-ai-sdk-dev/.claude-plugin/plugin.json
+++ b/plugins/nextjs-supabase-ai-sdk-dev/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "constellos"
   },
-  "repository": "https://github.com/constellos/claude-code-plugins",
+  "repository": "https://github.com/constellos/claude-code",
   "license": "MIT",
   "keywords": ["nextjs", "supabase", "ai-sdk", "development"],
   "mcpServers": {

--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/link-vercel-apps.ts
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/link-vercel-apps.ts
@@ -164,6 +164,18 @@ function detectTurborepoWorkspaces(cwd: string): string[] | null {
 }
 
 /**
+ * Check if an app directory is a Cloudflare Workers project
+ * (has wrangler.toml, wrangler.json, or wrangler.jsonc)
+ */
+function isCloudflareProject(appPath: string): boolean {
+  return (
+    existsSync(join(appPath, 'wrangler.toml')) ||
+    existsSync(join(appPath, 'wrangler.json')) ||
+    existsSync(join(appPath, 'wrangler.jsonc'))
+  );
+}
+
+/**
  * Try to find a matching Vercel project for an app
  * Uses the app directory name as the project name guess
  */
@@ -277,6 +289,13 @@ async function handler(input: SessionStartInput): Promise<SessionStartHookOutput
     for (const workspace of workspaces) {
       const appPath = join(input.cwd, workspace);
       const appName = basename(workspace);
+
+      // Skip Cloudflare Workers projects (they have wrangler config files)
+      if (isCloudflareProject(appPath)) {
+        messages.push(`  ⏭ ${appName} is a Cloudflare project, skipping`);
+        skippedCount++;
+        continue;
+      }
 
       // Check if already linked
       const existingLink = isVercelLinked(appPath);

--- a/plugins/project-context/.claude-plugin/plugin.json
+++ b/plugins/project-context/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "constellos"
   },
-  "repository": "https://github.com/constellos/claude-code-plugins",
+  "repository": "https://github.com/constellos/claude-code",
   "license": "MIT",
   "keywords": [
     "project-context",


### PR DESCRIPTION
## Summary
- **Fix phantom Vercel projects**: Added Cloudflare project detection (`wrangler.toml`/`.json`/`.jsonc`) to `link-vercel-apps.ts` SessionStart hook so Cloudflare Workers apps in turborepo `apps/` are skipped instead of being auto-linked to Vercel
- **Rename repo**: Updated all references from `claude-code-plugins` to `claude-code` across `package.json`, `README.md`, `claude-worktree.sh`, all `plugin.json` files, and the cloudflare plugin README. GitHub repo renamed via `gh repo rename`

Closes #346

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes
- [x] `gh repo view` confirms rename to `constellos/claude-code`
- [x] Grep confirms no stale `claude-code-plugins` references in tracked source files (remaining only in logs, lock files, and local settings as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)