### PR TITLE
fix(nextjs-supabase-ai-sdk-dev): Strip MCP servers and unnecessary SessionStart hooks

### DIFF
--- a/plugins/nextjs-supabase-ai-sdk-dev/.claude-plugin/plugin.json
+++ b/plugins/nextjs-supabase-ai-sdk-dev/.claude-plugin/plugin.json
@@ -7,23 +7,5 @@
   },
   "repository": "https://github.com/constellos/claude-code",
   "license": "MIT",
-  "keywords": ["nextjs", "supabase", "ai-sdk", "development"],
-  "mcpServers": {
-    "nodes": {
-      "command": "npx",
-      "args": ["-y", "nodes-md@latest"]
-    },
-    "ai-elements": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote@latest", "https://registry.ai-sdk.dev/api/mcp"]
-    },
-    "supabase": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote@latest", "https://mcp.supabase.com/mcp"]
-    },
-    "vercel": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote@latest", "https://mcp.vercel.com"]
-    }
-  }
+  "keywords": ["nextjs", "supabase", "ai-sdk", "development"]
 }

--- a/plugins/nextjs-supabase-ai-sdk-dev/CLAUDE.md
+++ b/plugins/nextjs-supabase-ai-sdk-dev/CLAUDE.md
@@ -19,9 +19,8 @@ Local dev environment setup for Vercel/Supabase and systematic UI development wi
 
 | Hook | Event | Blocking | Purpose |
 |------|-------|----------|---------|
-| install-vercel | SessionStart | No | Installs Vercel CLI |
+| link-vercel-apps | SessionStart | No | Auto-links monorepo apps to Vercel projects and pulls env vars |
 | install-start-supabase-next | SessionStart | No | Sets up Supabase local dev, installs dependencies (skips if fresh), starts dev servers (Next.js, Cloudflare, Elysia, Turborepo) with health checks |
-| cache-supabase-schema | SessionStart | No | Caches Supabase table/column metadata for context matching |
 | run-file-eslint | PostToolUse[Write\|Edit] | Yes | Runs ESLint on edited files |
 | run-file-vitests | PostToolUse[Write\|Edit] | No | Runs related tests (warns only) |
 | move-playwright-screenshots | PostToolUse[browser_eval] | No | Moves screenshots to .claude/screenshots/ to prevent permission prompts |

--- a/plugins/nextjs-supabase-ai-sdk-dev/hooks/hooks.json
+++ b/plugins/nextjs-supabase-ai-sdk-dev/hooks/hooks.json
@@ -33,23 +33,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/setup-nodes-config.ts",
-            "description": "Creates .nodes/.mcp.nodes.json config for the nodes-md MCP proxy"
-          },
-          {
-            "type": "command",
-            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/install-vercel.ts",
-            "description": "Installs Vercel CLI on remote, warns if missing on local"
-          },
-          {
-            "type": "command",
             "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/link-vercel-apps.ts",
             "description": "Auto-links monorepo apps to Vercel projects and pulls env vars"
-          },
-          {
-            "type": "command",
-            "command": "npx tsx ${CLAUDE_PLUGIN_ROOT}/hooks/cache-supabase-schema.ts",
-            "description": "Caches Supabase table/column metadata for context matching. Checks for stale cache and provides refresh instructions."
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Remove all 4 MCP servers (nodes, ai-elements, supabase, vercel) from plugin.json
- Remove 3 SessionStart hooks (setup-nodes-config, install-vercel, cache-supabase-schema) from hooks.json, keeping only link-vercel-apps
- Update CLAUDE.md hook summary table to match

## Test plan
- [x] `plugin.json` has no `mcpServers` key
- [x] `hooks.json` SessionStart only contains `link-vercel-apps.ts`
- [x] Both JSON files parse without errors
- [x] `tsc --noEmit` passes

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)